### PR TITLE
feat: pointer image for freehand

### DIFF
--- a/src/animate.ts
+++ b/src/animate.ts
@@ -476,6 +476,16 @@ const patchSvgFreedraw = (
   animate.setAttribute("dur", `${1}ms`);
   animate.setAttribute("fill", "freeze");
   childNode.appendChild(animate);
+  animatePointer(
+    svg,
+    childNode,
+    freeDrawElement.points.reduce(
+      (p, [x, y]) => (p ? p + ` T ${x} ${y}` : `M ${x} ${y}`),
+      ""
+    ),
+    currentMs,
+    durationMs
+  );
 
   // interporation
   const repeat = freeDrawElement.points.length;


### PR DESCRIPTION
Continuing #11, support freehand.
The path for freehand is not precise like other shapes, but it should be fine. (For other shapes, it can be too precise. 😅 )

This work is sponsored by [ReactEurope](https://www.react-europe.org/).


https://user-images.githubusercontent.com/490574/117819366-70190280-b2a4-11eb-9f93-a5738e8d1a82.mov

