### PR TITLE
only compile library code into dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:lint": "eslint --max-warnings=0 --ext .js,.ts,.tsx --ignore-pattern dist.",
     "test:format": "prettier 'src/*.(js|ts|tsx|css|scss)' --list-different",
     "test:app": "react-scripts test --passWithNoTests",
-    "compile": "tsc --noEmit false --declaration --outDir dist && cp src/*.css dist && cp src/vendor/LICENSE dist/vendor"
+    "compile": "tsc -p tsconfig.build.json"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:lint": "eslint --max-warnings=0 --ext .js,.ts,.tsx --ignore-pattern dist.",
     "test:format": "prettier 'src/*.(js|ts|tsx|css|scss)' --list-different",
     "test:app": "react-scripts test --passWithNoTests",
-    "compile": "tsc --noEmit false --declaration --outDir dist"
+    "compile": "tsc --noEmit false --declaration --outDir dist && cp src/*.css dist && cp src/vendor/LICENSE dist/vendor"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "outDir": "dist"
+  },
+  "include": ["src/library.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
@LiveDuo pointed out that *.css files can't be referenced in the dist folder. Hope this helps, but I'm not sure the real use cases.