### PR TITLE
fix: Apply temporary logic to apply missing fonts in the current excalidraw package

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,30 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Excalidraw Animate</title>
+    <!-- Links for Lilita One font. Remove these links once Excalidraw is updated to the next version (v0.17.6 as of now) -->
+      <link rel="preconnect" href="https://fonts.googleapis.com">
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+      <link href="https://fonts.googleapis.com/css2?family=Lilita+One&display=swap" rel="stylesheet">
+    <style>
+      /* Styles for additional fonts that are not part of Excalidraw package in the current version.
+       Remove them all once Excalidraw is updated (v0.17.6 as of now) */
+      @font-face {
+        font-family: 'Excalifont'; 
+        src: url('https://excalidraw.nyc3.cdn.digitaloceanspaces.com/fonts/oss/Excalifont-Regular-C9eKQy_N.woff2'); 
+      }
+      @font-face {
+        font-family: 'Comic Shanns'; 
+        src: url('https://excalidraw.nyc3.cdn.digitaloceanspaces.com/fonts/oss/ComicShanns-Regular-D0c8wzsC.woff2'); 
+      }
+      @font-face {
+        font-family: 'Nunito'; 
+        src: url('https://fonts.gstatic.com/s/nunito/v26/XRXI3I6Li01BKofiOc5wtlZ2di8HDIkhdTQ3j6zbXWjgeg.woff2'); 
+      }
+      @font-face {
+        font-family: 'Lilita One'; 
+        src: url('https://fonts.googleapis.com/css2?family=Lilita+One&display=swap'); 
+      }
+    </style>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/animate.ts
+++ b/src/animate.ts
@@ -290,20 +290,22 @@ const animateText = (
   pathForTextIndex += 1;
   const path = svg.ownerDocument.createElementNS(SVG_NS, "path");
   path.setAttribute("id", "pathForText" + pathForTextIndex);
+
+  const textPath = svg.ownerDocument.createTextNode(ele.textContent ?? "");
+  ele.textContent = " "; // HACK for Firebox as `null` does not work
+  ele.appendChild(textPath);
+  ele.setAttribute("opacity", "0.0");
+
   const animate = svg.ownerDocument.createElementNS(SVG_NS, "animate");
-  animate.setAttribute("attributeName", "d");
-  animate.setAttribute("from", `m${x} ${y} h0`);
-  animate.setAttribute("to", `m${x} ${y} h${width}`);
+  animate.setAttribute("attributeName", "opacity");
+  animate.setAttribute("from", `0.0`);
+  animate.setAttribute("to", `1.0`);
   animate.setAttribute("begin", `${currentMs}ms`);
   animate.setAttribute("dur", `${durationMs}ms`);
   animate.setAttribute("fill", "freeze");
-  path.appendChild(animate);
-  const textPath = svg.ownerDocument.createElementNS(SVG_NS, "textPath");
-  textPath.setAttribute("href", "#pathForText" + pathForTextIndex);
-  textPath.textContent = ele.textContent;
-  ele.textContent = " "; // HACK for Firebox as `null` does not work
+  ele.appendChild(animate);
+
   findNode(svg, "defs")?.appendChild(path);
-  ele.appendChild(textPath);
   animatePointer(
     svg,
     ele,

--- a/src/useLoadSvg.ts
+++ b/src/useLoadSvg.ts
@@ -159,9 +159,21 @@ function applyNewFontsToSvg(svg: SVGSVGElement, elements: ExcalidrawElement[]) {
       element.type === "text" && !!element.fontFamily
   ) as ExcalidrawTextElement[];
 
-  svg.querySelectorAll("text").forEach((textElement, index) => {
-    const fontFamily = textElements[index]?.fontFamily;
-    convertFontFamily(textElement, fontFamily);
+  /** index to keep track of block of text elements */
+  let currentTextElementIndex = 0;
+
+  // Since text element is represented in a group in given svg
+  // apply font family based on the group that contains the text elements
+  svg.querySelectorAll("g").forEach((svgGroup) => {
+    // It indicates the group is not for text - thus skip it
+    if (svgGroup.hasAttribute("stroke-linecap")) return;
+
+    const fontFamily = textElements[currentTextElementIndex]?.fontFamily;
+    svgGroup.querySelectorAll("text").forEach((svgText) => {
+      convertFontFamily(svgText, fontFamily);
+    });
+
+    currentTextElementIndex += 1;
   });
 }
 

--- a/src/useLoadSvg.ts
+++ b/src/useLoadSvg.ts
@@ -9,6 +9,7 @@ import {
 import type { BinaryFiles } from "@excalidraw/excalidraw/types/types";
 import type {
   ExcalidrawElement,
+  ExcalidrawTextElement,
   NonDeletedExcalidrawElement,
 } from "@excalidraw/excalidraw/types/element/types";
 
@@ -16,10 +17,10 @@ import { loadScene } from "./vendor/loadScene";
 import { animateSvg } from "./animate";
 
 export const getNonDeletedElements = (
-  elements: readonly ExcalidrawElement[]
+  elements: readonly ExcalidrawElement[],
 ): NonDeletedExcalidrawElement[] =>
   elements.filter(
-    (element): element is NonDeletedExcalidrawElement => !element.isDeleted
+    (element): element is NonDeletedExcalidrawElement => !element.isDeleted,
   );
 
 const importLibraryFromUrl = async (url: string) => {
@@ -28,7 +29,7 @@ const importLibraryFromUrl = async (url: string) => {
     const blob = await request.blob();
     const libraryItems = await loadLibraryFromBlob(blob);
     return libraryItems.map((libraryItem) =>
-      getNonDeletedElements(restoreElements(libraryItem.elements, null))
+      getNonDeletedElements(restoreElements(libraryItem.elements, null)),
     );
   } catch (error) {
     window.alert("Unable to load library");
@@ -52,7 +53,7 @@ export const useLoadSvg = () => {
         appState: Parameters<typeof exportToSvg>[0]["appState"];
         files: BinaryFiles;
       }[],
-      inSequence?: boolean
+      inSequence?: boolean,
     ) => {
       const hash = window.location.hash.slice(1);
       const searchParams = new URLSearchParams(hash);
@@ -65,24 +66,30 @@ export const useLoadSvg = () => {
       const svgList = await Promise.all(
         dataList.map(async (data) => {
           const elements = getNonDeletedElements(data.elements);
+
           const svg = await exportToSvg({
             elements,
             files: data.files,
             appState: data.appState,
             exportPadding: 30,
           });
+
+          // This is a patch up function to apply new fonts that are not part of Excalidraw package
+          // Remove this function once Excalidraw package is updated (v0.17.6 as of now)
+          applyNewFontsToSvg(svg, elements);
+
           const result = animateSvg(svg, elements, options);
           console.log(svg);
           if (inSequence) {
             options.startMs = result.finishedMs;
           }
           return { svg, finishedMs: result.finishedMs };
-        })
+        }),
       );
       setLoadedSvgList(svgList);
       return svgList;
     },
-    []
+    [],
   );
 
   useEffect(() => {
@@ -90,7 +97,7 @@ export const useLoadSvg = () => {
       const hash = window.location.hash.slice(1);
       const searchParams = new URLSearchParams(hash);
       const matchIdKey = /([a-zA-Z0-9_-]+),?([a-zA-Z0-9_-]*)/.exec(
-        searchParams.get("json") || ""
+        searchParams.get("json") || "",
       );
       if (matchIdKey) {
         const [, id, key] = matchIdKey;
@@ -101,14 +108,14 @@ export const useLoadSvg = () => {
         }
       }
       const matchLibrary = /(.*\.excalidrawlib)/.exec(
-        searchParams.get("library") || ""
+        searchParams.get("library") || "",
       );
       if (matchLibrary) {
         const [, url] = matchLibrary;
         const dataList = await importLibraryFromUrl(url);
         const svgList = await loadDataList(
           dataList.map((elements) => ({ elements, appState: {}, files: {} })),
-          searchParams.has("sequence")
+          searchParams.has("sequence"),
         );
         if (searchParams.get("autoplay") === "no") {
           svgList.forEach(({ svg, finishedMs }) => {
@@ -122,3 +129,85 @@ export const useLoadSvg = () => {
 
   return { loading, loadedSvgList, loadDataList };
 };
+
+// Change below are to apply new fonts that are not part of current version of Excalidraw package
+// Remove them all below once Excalidraw is updated (v0.17.6 as of now)
+// ================================================
+const DEFAULT_FONT = "Segoe UI Emoji";
+/** Up to date version of font family. It's brought from the latest version of Excalidraw repo */
+export const FONT_FAMILY = {
+  Virgil: 1,
+  Helvetica: 2,
+  Cascadia: 3,
+  // leave 4 unused as it was historically used for Assistant (which we don't use anymore) or custom font (Obsidian)
+  Excalifont: 5,
+  Nunito: 6,
+  "Lilita One": 7,
+  "Comic Shanns": 8,
+  "Liberation Sans": 9,
+} as const;
+
+/**
+ * Recursively apply new fonts to all text elements in the given SVG.
+ * `exportToSvg()` is not compatible with new fonts due to a discrepancy between package and release excalidraw.
+ * This function patches up the fonts resulting in a default font family.
+ *
+ * issue link: https://github.com/dai-shi/excalidraw-animate/issues/55
+ *  */
+function applyNewFontsToSvg(svg: SVGSVGElement, elements: ExcalidrawElement[]) {
+  const textElements: ExcalidrawTextElement[] = elements.filter(
+    (element): element is ExcalidrawTextElement =>
+      element.type === "text" && !!element.fontFamily,
+  ) as ExcalidrawTextElement[];
+
+  svg.querySelectorAll("text").forEach((textElement, index) => {
+    const fontFamily = textElements[index].fontFamily;
+    convertFontFamily(textElement, fontFamily);
+  });
+}
+
+function convertFontFamily(
+  textElement: SVGTextElement,
+  fontFamilyNumber: number,
+) {
+  switch (fontFamilyNumber) {
+    case FONT_FAMILY.Virgil:
+      textElement.setAttribute("font-family", `Virgil, ${DEFAULT_FONT}`);
+      break;
+
+    case FONT_FAMILY.Helvetica:
+      textElement.setAttribute("font-family", `Helvetica, ${DEFAULT_FONT}`);
+      break;
+
+    case FONT_FAMILY.Cascadia:
+      textElement.setAttribute("font-family", `Cascadia, ${DEFAULT_FONT}`);
+      break;
+
+    case FONT_FAMILY.Excalifont:
+      textElement.setAttribute("font-family", `Excalifont, ${DEFAULT_FONT}`);
+      break;
+
+    case FONT_FAMILY.Nunito:
+      textElement.setAttribute("font-family", `Nunito, ${DEFAULT_FONT}`);
+      break;
+
+    case FONT_FAMILY["Lilita One"]:
+      textElement.setAttribute("font-family", `Lilita One, ${DEFAULT_FONT}`);
+      break;
+
+    case FONT_FAMILY["Comic Shanns"]:
+      textElement.setAttribute("font-family", `Comic Shanns, ${DEFAULT_FONT}`);
+      break;
+
+    case FONT_FAMILY["Liberation Sans"]:
+      textElement.setAttribute(
+        "font-family",
+        `Liberation Sans, ${DEFAULT_FONT}`,
+      );
+      break;
+
+    default:
+      textElement.setAttribute("font-family", DEFAULT_FONT);
+      break;
+  }
+}

--- a/src/useLoadSvg.ts
+++ b/src/useLoadSvg.ts
@@ -17,10 +17,10 @@ import { loadScene } from "./vendor/loadScene";
 import { animateSvg } from "./animate";
 
 export const getNonDeletedElements = (
-  elements: readonly ExcalidrawElement[]
+  elements: readonly ExcalidrawElement[],
 ): NonDeletedExcalidrawElement[] =>
   elements.filter(
-    (element): element is NonDeletedExcalidrawElement => !element.isDeleted
+    (element): element is NonDeletedExcalidrawElement => !element.isDeleted,
   );
 
 const importLibraryFromUrl = async (url: string) => {
@@ -29,7 +29,7 @@ const importLibraryFromUrl = async (url: string) => {
     const blob = await request.blob();
     const libraryItems = await loadLibraryFromBlob(blob);
     return libraryItems.map((libraryItem) =>
-      getNonDeletedElements(restoreElements(libraryItem.elements, null))
+      getNonDeletedElements(restoreElements(libraryItem.elements, null)),
     );
   } catch (error) {
     window.alert("Unable to load library");
@@ -53,7 +53,7 @@ export const useLoadSvg = () => {
         appState: Parameters<typeof exportToSvg>[0]["appState"];
         files: BinaryFiles;
       }[],
-      inSequence?: boolean
+      inSequence?: boolean,
     ) => {
       const hash = window.location.hash.slice(1);
       const searchParams = new URLSearchParams(hash);
@@ -83,12 +83,12 @@ export const useLoadSvg = () => {
             options.startMs = result.finishedMs;
           }
           return { svg, finishedMs: result.finishedMs };
-        })
+        }),
       );
       setLoadedSvgList(svgList);
       return svgList;
     },
-    []
+    [],
   );
 
   useEffect(() => {
@@ -96,7 +96,7 @@ export const useLoadSvg = () => {
       const hash = window.location.hash.slice(1);
       const searchParams = new URLSearchParams(hash);
       const matchIdKey = /([a-zA-Z0-9_-]+),?([a-zA-Z0-9_-]*)/.exec(
-        searchParams.get("json") || ""
+        searchParams.get("json") || "",
       );
       if (matchIdKey) {
         const [, id, key] = matchIdKey;
@@ -107,14 +107,14 @@ export const useLoadSvg = () => {
         }
       }
       const matchLibrary = /(.*\.excalidrawlib)/.exec(
-        searchParams.get("library") || ""
+        searchParams.get("library") || "",
       );
       if (matchLibrary) {
         const [, url] = matchLibrary;
         const dataList = await importLibraryFromUrl(url);
         const svgList = await loadDataList(
           dataList.map((elements) => ({ elements, appState: {}, files: {} })),
-          searchParams.has("sequence")
+          searchParams.has("sequence"),
         );
         if (searchParams.get("autoplay") === "no") {
           svgList.forEach(({ svg, finishedMs }) => {
@@ -156,18 +156,18 @@ export const FONT_FAMILY = {
 function applyNewFontsToSvg(svg: SVGSVGElement, elements: ExcalidrawElement[]) {
   const textElements: ExcalidrawTextElement[] = elements.filter(
     (element): element is ExcalidrawTextElement =>
-      element.type === "text" && !!element.fontFamily
+      element.type === "text" && !!element.fontFamily,
   ) as ExcalidrawTextElement[];
 
   svg.querySelectorAll("text").forEach((textElement, index) => {
-    const fontFamily = textElements[index].fontFamily;
+    const fontFamily = textElements[index]?.fontFamily;
     convertFontFamily(textElement, fontFamily);
   });
 }
 
 function convertFontFamily(
   textElement: SVGTextElement,
-  fontFamilyNumber: number
+  fontFamilyNumber: number | undefined,
 ) {
   switch (fontFamilyNumber) {
     case FONT_FAMILY.Virgil:
@@ -201,7 +201,7 @@ function convertFontFamily(
     case FONT_FAMILY["Liberation Sans"]:
       textElement.setAttribute(
         "font-family",
-        `Liberation Sans, ${DEFAULT_FONT}`
+        `Liberation Sans, ${DEFAULT_FONT}`,
       );
       break;
 

--- a/src/useLoadSvg.ts
+++ b/src/useLoadSvg.ts
@@ -114,7 +114,7 @@ export const useLoadSvg = () => {
         const dataList = await importLibraryFromUrl(url);
         const svgList = await loadDataList(
           dataList.map((elements) => ({ elements, appState: {}, files: {} })),
-          searchParams.has("sequence"),
+          searchParams.has("sequence")
         );
         if (searchParams.get("autoplay") === "no") {
           svgList.forEach(({ svg, finishedMs }) => {

--- a/src/useLoadSvg.ts
+++ b/src/useLoadSvg.ts
@@ -17,10 +17,10 @@ import { loadScene } from "./vendor/loadScene";
 import { animateSvg } from "./animate";
 
 export const getNonDeletedElements = (
-  elements: readonly ExcalidrawElement[],
+  elements: readonly ExcalidrawElement[]
 ): NonDeletedExcalidrawElement[] =>
   elements.filter(
-    (element): element is NonDeletedExcalidrawElement => !element.isDeleted,
+    (element): element is NonDeletedExcalidrawElement => !element.isDeleted
   );
 
 const importLibraryFromUrl = async (url: string) => {
@@ -29,7 +29,7 @@ const importLibraryFromUrl = async (url: string) => {
     const blob = await request.blob();
     const libraryItems = await loadLibraryFromBlob(blob);
     return libraryItems.map((libraryItem) =>
-      getNonDeletedElements(restoreElements(libraryItem.elements, null)),
+      getNonDeletedElements(restoreElements(libraryItem.elements, null))
     );
   } catch (error) {
     window.alert("Unable to load library");
@@ -53,7 +53,7 @@ export const useLoadSvg = () => {
         appState: Parameters<typeof exportToSvg>[0]["appState"];
         files: BinaryFiles;
       }[],
-      inSequence?: boolean,
+      inSequence?: boolean
     ) => {
       const hash = window.location.hash.slice(1);
       const searchParams = new URLSearchParams(hash);
@@ -66,7 +66,6 @@ export const useLoadSvg = () => {
       const svgList = await Promise.all(
         dataList.map(async (data) => {
           const elements = getNonDeletedElements(data.elements);
-
           const svg = await exportToSvg({
             elements,
             files: data.files,
@@ -84,12 +83,12 @@ export const useLoadSvg = () => {
             options.startMs = result.finishedMs;
           }
           return { svg, finishedMs: result.finishedMs };
-        }),
+        })
       );
       setLoadedSvgList(svgList);
       return svgList;
     },
-    [],
+    []
   );
 
   useEffect(() => {
@@ -97,7 +96,7 @@ export const useLoadSvg = () => {
       const hash = window.location.hash.slice(1);
       const searchParams = new URLSearchParams(hash);
       const matchIdKey = /([a-zA-Z0-9_-]+),?([a-zA-Z0-9_-]*)/.exec(
-        searchParams.get("json") || "",
+        searchParams.get("json") || ""
       );
       if (matchIdKey) {
         const [, id, key] = matchIdKey;
@@ -108,14 +107,14 @@ export const useLoadSvg = () => {
         }
       }
       const matchLibrary = /(.*\.excalidrawlib)/.exec(
-        searchParams.get("library") || "",
+        searchParams.get("library") || ""
       );
       if (matchLibrary) {
         const [, url] = matchLibrary;
         const dataList = await importLibraryFromUrl(url);
         const svgList = await loadDataList(
           dataList.map((elements) => ({ elements, appState: {}, files: {} })),
-          searchParams.has("sequence"),
+          searchParams.has("sequence")
         );
         if (searchParams.get("autoplay") === "no") {
           svgList.forEach(({ svg, finishedMs }) => {
@@ -157,7 +156,7 @@ export const FONT_FAMILY = {
 function applyNewFontsToSvg(svg: SVGSVGElement, elements: ExcalidrawElement[]) {
   const textElements: ExcalidrawTextElement[] = elements.filter(
     (element): element is ExcalidrawTextElement =>
-      element.type === "text" && !!element.fontFamily,
+      element.type === "text" && !!element.fontFamily
   ) as ExcalidrawTextElement[];
 
   svg.querySelectorAll("text").forEach((textElement, index) => {
@@ -168,7 +167,7 @@ function applyNewFontsToSvg(svg: SVGSVGElement, elements: ExcalidrawElement[]) {
 
 function convertFontFamily(
   textElement: SVGTextElement,
-  fontFamilyNumber: number,
+  fontFamilyNumber: number
 ) {
   switch (fontFamilyNumber) {
     case FONT_FAMILY.Virgil:
@@ -202,7 +201,7 @@ function convertFontFamily(
     case FONT_FAMILY["Liberation Sans"]:
       textElement.setAttribute(
         "font-family",
-        `Liberation Sans, ${DEFAULT_FONT}`,
+        `Liberation Sans, ${DEFAULT_FONT}`
       );
       break;
 

--- a/src/useLoadSvg.ts
+++ b/src/useLoadSvg.ts
@@ -17,10 +17,10 @@ import { loadScene } from "./vendor/loadScene";
 import { animateSvg } from "./animate";
 
 export const getNonDeletedElements = (
-  elements: readonly ExcalidrawElement[],
+  elements: readonly ExcalidrawElement[]
 ): NonDeletedExcalidrawElement[] =>
   elements.filter(
-    (element): element is NonDeletedExcalidrawElement => !element.isDeleted,
+    (element): element is NonDeletedExcalidrawElement => !element.isDeleted
   );
 
 const importLibraryFromUrl = async (url: string) => {
@@ -29,7 +29,7 @@ const importLibraryFromUrl = async (url: string) => {
     const blob = await request.blob();
     const libraryItems = await loadLibraryFromBlob(blob);
     return libraryItems.map((libraryItem) =>
-      getNonDeletedElements(restoreElements(libraryItem.elements, null)),
+      getNonDeletedElements(restoreElements(libraryItem.elements, null))
     );
   } catch (error) {
     window.alert("Unable to load library");
@@ -53,7 +53,7 @@ export const useLoadSvg = () => {
         appState: Parameters<typeof exportToSvg>[0]["appState"];
         files: BinaryFiles;
       }[],
-      inSequence?: boolean,
+      inSequence?: boolean
     ) => {
       const hash = window.location.hash.slice(1);
       const searchParams = new URLSearchParams(hash);
@@ -83,12 +83,12 @@ export const useLoadSvg = () => {
             options.startMs = result.finishedMs;
           }
           return { svg, finishedMs: result.finishedMs };
-        }),
+        })
       );
       setLoadedSvgList(svgList);
       return svgList;
     },
-    [],
+    []
   );
 
   useEffect(() => {
@@ -96,7 +96,7 @@ export const useLoadSvg = () => {
       const hash = window.location.hash.slice(1);
       const searchParams = new URLSearchParams(hash);
       const matchIdKey = /([a-zA-Z0-9_-]+),?([a-zA-Z0-9_-]*)/.exec(
-        searchParams.get("json") || "",
+        searchParams.get("json") || ""
       );
       if (matchIdKey) {
         const [, id, key] = matchIdKey;
@@ -107,7 +107,7 @@ export const useLoadSvg = () => {
         }
       }
       const matchLibrary = /(.*\.excalidrawlib)/.exec(
-        searchParams.get("library") || "",
+        searchParams.get("library") || ""
       );
       if (matchLibrary) {
         const [, url] = matchLibrary;
@@ -156,7 +156,7 @@ export const FONT_FAMILY = {
 function applyNewFontsToSvg(svg: SVGSVGElement, elements: ExcalidrawElement[]) {
   const textElements: ExcalidrawTextElement[] = elements.filter(
     (element): element is ExcalidrawTextElement =>
-      element.type === "text" && !!element.fontFamily,
+      element.type === "text" && !!element.fontFamily
   ) as ExcalidrawTextElement[];
 
   svg.querySelectorAll("text").forEach((textElement, index) => {
@@ -167,7 +167,7 @@ function applyNewFontsToSvg(svg: SVGSVGElement, elements: ExcalidrawElement[]) {
 
 function convertFontFamily(
   textElement: SVGTextElement,
-  fontFamilyNumber: number | undefined,
+  fontFamilyNumber: number | undefined
 ) {
   switch (fontFamilyNumber) {
     case FONT_FAMILY.Virgil:
@@ -201,7 +201,7 @@ function convertFontFamily(
     case FONT_FAMILY["Liberation Sans"]:
       textElement.setAttribute(
         "font-family",
-        `Liberation Sans, ${DEFAULT_FONT}`,
+        `Liberation Sans, ${DEFAULT_FONT}`
       );
       break;
 


### PR DESCRIPTION
## Issue
https://github.com/dai-shi/excalidraw-animate/issues/55

## What the change is about
It turned out that the `@excalidraw/excalidraw` package is way behind the released app version, hence the issue as the package doesn't know any added fonts that are present in the app. This PR adds fonts and logic to apply missing fonts and adopt newly added fonts so that this app can display any fonts in the current version of the excalidraw.

@dai-shi This is a bit of an ugly patch-up to manually apply missing fonts in the package until we get the update from Excalidraw. It at least does its job to adopt the fonts but I'd say it's up to you to have this change meanwhile or wait for their update without it!

### Screenshot / Gif
**Base canvas in Excalidraw**
![Screenshot 2024-08-08 at 5 46 00 PM](https://github.com/user-attachments/assets/5df9529c-4464-47e6-9e7e-d52686086726)

**Imported svg**
![2024-08-08 17 34 53](https://github.com/user-attachments/assets/b976f2ae-8702-4cdf-966f-2c311593194a)
