### PR TITLE
add base path to deploy to gh-page

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react";
 import { configDefaults } from "vitest/config";
 
 export default defineConfig({
+  base: "/excalidraw-animate/",
   plugins: [react()],
   build: {
     outDir: "build",


### PR DESCRIPTION
In vite's official [docs](https://vite.dev/guide/static-deploy.html#github-pages), The value of `/excalidraw-animate/`should be added to the `base` property. 