### PR TITLE
style: align toolbar/button styling with Excalidraw 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,16 +43,7 @@ const App = () => {
 
   return (
     <div>
-      <button
-        onClick={toggleMode}
-        style={{
-          position: 'absolute',
-          top: 1,
-          left: 1,
-          fontSize: 8,
-          zIndex: 10,
-        }}
-      >
+      <button className="app-button app-button-compact" onClick={toggleMode}>
         {mode === 'animate' ? 'Edit' : 'Animate'}
       </button>
       {mode === 'animate' ? (

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -219,7 +219,9 @@ const Toolbar = ({ svgList, loadDataList }: Props) => {
 
   return (
     <div>
-      <div className={`toolbar ${showToolbar === true ? '' : 'toolbar--hidden'}`}>
+      <div
+        className={`toolbar ${showToolbar === true ? '' : 'toolbar--hidden'}`}
+      >
         <button type="button" onClick={loadFile} className="app-button">
           Load File
         </button>
@@ -245,14 +247,26 @@ const Toolbar = ({ svgList, loadDataList }: Props) => {
         </form>
       </div>
       {!!svgList.length && (
-      <div className="toolbar">
-          <button type="button" onClick={togglePausedAnimations} className="app-button">
+        <div className="toolbar">
+          <button
+            type="button"
+            onClick={togglePausedAnimations}
+            className="app-button"
+          >
             {paused ? 'Play (P)' : 'Pause (P)'}
           </button>
-          <button type="button" onClick={stepForwardAnimations} className="app-button">
+          <button
+            type="button"
+            onClick={stepForwardAnimations}
+            className="app-button"
+          >
             Step (S)
           </button>
-          <button type="button" onClick={resetAnimations} className="app-button">
+          <button
+            type="button"
+            onClick={resetAnimations}
+            className="app-button"
+          >
             Reset (R)
           </button>
           <button type="button" onClick={hideToolbar} className="app-button">

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -219,73 +219,53 @@ const Toolbar = ({ svgList, loadDataList }: Props) => {
 
   return (
     <div>
-      <div style={{ margin: '3px 3px 3px 40px' }}>
-        <button type="button" onClick={loadFile} style={{ marginRight: 3 }}>
+      <div className={`toolbar ${showToolbar === true ? '' : 'toolbar--hidden'}`}>
+        <button type="button" onClick={loadFile} className="app-button">
           Load File
         </button>
-        <span style={{ marginRight: 3 }}>OR</span>
-        <button type="button" onClick={loadLibrary} style={{ marginRight: 3 }}>
+        <span>OR</span>
+        <button type="button" onClick={loadLibrary} className="app-button">
           Load Library
         </button>
         <span>OR</span>
-        <form onSubmit={loadLink} style={{ display: 'inline' }}>
+        <form onSubmit={loadLink}>
           <input
+            className="app-input"
             placeholder="Enter link..."
             value={link}
             onChange={(e) => setLink(e.target.value)}
-            style={{ marginLeft: 3, marginRight: 3 }}
           />
           <button
             type="submit"
             disabled={!linkRegex.test(link)}
-            style={{ marginRight: 3 }}
+            className="app-button"
           >
             Animate!
           </button>
         </form>
       </div>
       {!!svgList.length && (
-        <div style={{ marginLeft: 3 }}>
-          <button
-            type="button"
-            onClick={togglePausedAnimations}
-            style={{ marginRight: 3 }}
-          >
+      <div className="toolbar">
+          <button type="button" onClick={togglePausedAnimations} className="app-button">
             {paused ? 'Play (P)' : 'Pause (P)'}
           </button>
-          <button
-            type="button"
-            onClick={stepForwardAnimations}
-            style={{ marginRight: 3 }}
-          >
+          <button type="button" onClick={stepForwardAnimations} className="app-button">
             Step (S)
           </button>
-          <button
-            type="button"
-            onClick={resetAnimations}
-            style={{ marginRight: 3 }}
-          >
+          <button type="button" onClick={resetAnimations} className="app-button">
             Reset (R)
           </button>
-          <button
-            type="button"
-            onClick={hideToolbar}
-            style={{ marginRight: 3 }}
-          >
+          <button type="button" onClick={hideToolbar} className="app-button">
             Hide Toolbar (Q)
           </button>
-          <button
-            type="button"
-            onClick={exportToSvg}
-            style={{ marginRight: 3 }}
-          >
+          <button type="button" onClick={exportToSvg} className="app-button">
             Export to SVG
           </button>
           <button
             type="button"
             onClick={exportToWebm}
             disabled={processing}
-            style={{ marginRight: 3 }}
+            className="app-button"
           >
             {processing
               ? 'Processing...'

--- a/src/index.css
+++ b/src/index.css
@@ -2,7 +2,9 @@
    This is a fallback to keep the same appearance for the outer DOM. */
 /* === Excalidraw tokens bridge (light defaults) === */
 :root {
-  --ui-font: Assistant, system-ui, BlinkMacSystemFont, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  --ui-font:
+    Assistant, system-ui, BlinkMacSystemFont, -apple-system, Segoe UI, Roboto,
+    Helvetica, Arial, sans-serif;
 
   /* sizes / radii */
   --font-size-sm: 0.75rem;
@@ -14,8 +16,8 @@
 
   /* surfaces / text */
   --color-surface-high: #f1f0ff;
-  --color-surface-mid:  #f6f6f9;
-  --color-surface-low:  #ececf4;
+  --color-surface-mid: #f6f6f9;
+  --color-surface-low: #ececf4;
   --color-surface-lowest: #ffffff;
   --color-on-surface: #1b1b1f;
 
@@ -97,11 +99,10 @@ code {
   }
 }
 
-
 /* Excalidraw styles: colors, size, border radius for outer DOM */
 .app-button {
   height: var(--lg-button-size);
-  padding: .625rem;
+  padding: 0.625rem;
   line-height: 0;
   background: var(--color-surface-low);
   border: none; /* Excalidraw often uses a 1px outline shadow instead of a border */
@@ -111,39 +112,45 @@ code {
 
   font-family: var(--ui-font);
   font-size: var(--font-size-sm);
-  letter-spacing: .4px;
+  letter-spacing: 0.4px;
   cursor: pointer;
 }
 
 .app-button-compact {
   position: absolute;
-  height: calc(var(--default-button-size) * 0.5); 
+  height: calc(var(--default-button-size) * 0.5);
   top: 1px;
   left: 1px;
   z-index: 10;
 }
 
 .app-button[disabled],
-.app-button[aria-disabled="true"] {
+.app-button[aria-disabled='true'] {
   opacity: 0.5;
-  border-color: var(--default-border-color); 
+  border-color: var(--default-border-color);
   cursor: not-allowed;
   pointer-events: none;
 }
 
-.app-button:hover  { background: var(--button-hover-bg); }
-.app-button:active { background: var(--button-active-bg); }
+.app-button:hover {
+  background: var(--button-hover-bg);
+}
+.app-button:active {
+  background: var(--button-active-bg);
+}
 
 .app-input {
   height: var(--lg-button-size);
-  box-sizing: border-box;                
+  box-sizing: border-box;
   border: 1.5px solid var(--input-border-color);
   border-radius: var(--space-factor);
-  font-size: var(--font-size-sm); 
+  font-size: var(--font-size-sm);
   min-width: 200px;
 }
 
-.app-input:not(:focus):hover { border-color: var(--color-brand-hover); }
+.app-input:not(:focus):hover {
+  border-color: var(--color-brand-hover);
+}
 .app-input:focus {
   outline: none;
   border-color: var(--color-brand-hover);
@@ -153,11 +160,11 @@ code {
   min-height: var(--lg-button-size);
   display: flex;
   align-items: center;
-  gap: 0.5rem;          
-  row-gap: 0.5rem;      
+  gap: 0.5rem;
+  row-gap: 0.5rem;
   padding-block: 1rem 0; /* top and bottom */
   padding-inline: 3rem 0; /* left and right */
-  transition: opacity .2s ease;
+  transition: opacity 0.2s ease;
 }
 
 .toolbar form {

--- a/src/index.css
+++ b/src/index.css
@@ -115,6 +115,14 @@ code {
   cursor: pointer;
 }
 
+.app-button-compact {
+  position: absolute;
+  height: calc(var(--default-button-size) * 0.5); 
+  top: 1px;
+  left: 1px;
+  z-index: 10;
+}
+
 .app-button[disabled],
 .app-button[aria-disabled="true"] {
   opacity: 0.5;
@@ -142,16 +150,13 @@ code {
 }
 
 .toolbar {
-  position: sticky;
-  top: 0;
-  z-index: 1000;
   min-height: var(--lg-button-size);
   display: flex;
   align-items: center;
   gap: 0.5rem;          
   row-gap: 0.5rem;      
-  padding-block: 0.5rem 0; /* top and bottom */
-  padding-inline: 0.5rem; /* left and right */
+  padding-block: 1rem 0; /* top and bottom */
+  padding-inline: 3rem 0; /* left and right */
   transition: opacity .2s ease;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,49 @@
+/* Under .excalidraw, variables from @excalidraw/excalidraw/index.css take precedence.
+   This is a fallback to keep the same appearance for the outer DOM. */
+/* === Excalidraw tokens bridge (light defaults) === */
+:root {
+  --ui-font: Assistant, system-ui, BlinkMacSystemFont, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+
+  /* sizes / radii */
+  --font-size-sm: 0.75rem;
+  --border-radius-lg: 0.5rem;
+  --lg-button-size: 2.25rem;
+  --lg-icon-size: 1rem;
+  --default-button-size: 2rem;
+  --default-icon-size: 1rem;
+
+  /* surfaces / text */
+  --color-surface-high: #f1f0ff;
+  --color-surface-mid:  #f6f6f9;
+  --color-surface-low:  #ececf4;
+  --color-surface-lowest: #ffffff;
+  --color-on-surface: #1b1b1f;
+
+  /* primary / brand */
+  --color-primary: #6965db;
+  --color-primary-darker: #5b57d1;
+  --color-primary-darkest: #4a47b1;
+  --color-primary-light: #e3e2fe;
+  --color-primary-light-darker: #d7d5ff;
+  --color-primary-hover: #5753d0;
+  --color-on-primary-container: #030064;
+  --color-brand-active: #4440bf;
+  --color-brand-hover: #5753d0;
+
+  /* inputs / borders */
+  --input-bg-color: #ffffff;
+  --input-border-color: #ced4da;
+  --default-border-color: var(--color-surface-high);
+
+  /* interaction */
+  --button-hover-bg: var(--color-surface-high);
+  --button-active-bg: var(--color-surface-high);
+  --button-active-border: var(--color-brand-active);
+
+  /* spacing */
+  --space-factor: 0.25rem;
+}
+
 body {
   margin: 0;
   font-family:
@@ -49,4 +95,75 @@ code {
   .GitHubCorner-container {
     display: none;
   }
+}
+
+
+/* Excalidraw styles: colors, size, border radius for outer DOM */
+.app-button {
+  height: var(--lg-button-size);
+  padding: .625rem;
+  line-height: 0;
+  background: var(--color-surface-low);
+  border: none; /* Excalidraw often uses a 1px outline shadow instead of a border */
+  border-radius: var(--border-radius-lg);
+  color: var(--color-on-surface);
+  box-shadow: 0 0 0 1px var(--color-surface-lowest);
+
+  font-family: var(--ui-font);
+  font-size: var(--font-size-sm);
+  letter-spacing: .4px;
+  cursor: pointer;
+}
+
+.app-button[disabled],
+.app-button[aria-disabled="true"] {
+  opacity: 0.5;
+  border-color: var(--default-border-color); 
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.app-button:hover  { background: var(--button-hover-bg); }
+.app-button:active { background: var(--button-active-bg); }
+
+.app-input {
+  height: var(--lg-button-size);
+  box-sizing: border-box;                
+  border: 1.5px solid var(--input-border-color);
+  border-radius: var(--space-factor);
+  font-size: var(--font-size-sm); 
+  min-width: 200px;
+}
+
+.app-input:not(:focus):hover { border-color: var(--color-brand-hover); }
+.app-input:focus {
+  outline: none;
+  border-color: var(--color-brand-hover);
+}
+
+.toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  min-height: var(--lg-button-size);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;          
+  row-gap: 0.5rem;      
+  padding-block: 0.5rem 0; /* top and bottom */
+  padding-inline: 0.5rem; /* left and right */
+  transition: opacity .2s ease;
+}
+
+.toolbar form {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Hidden state: keeps height, disables interaction, and only hides visually */
+.toolbar--hidden {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
 }


### PR DESCRIPTION
- Applied toolbar/button styling in index.css, using color, spacing, border-radius, and shadow values from theme.scss (packages/excalidraw/css/theme.scss)
- Kept the layout when hiding the toolbar
- Enabled toolbar to hide on scroll
- Kept Edit/Animate buttons in the same position and matched Excalidraw style

Resolves #89


https://github.com/user-attachments/assets/40092dce-fffd-4529-bdf9-e28a9d81e54c

