### PR TITLE
style: improve AnimateConfig UI with headings, units, and wording

### DIFF
--- a/src/AnimateConfig.tsx
+++ b/src/AnimateConfig.tsx
@@ -158,16 +158,18 @@ export const AnimateConfig = ({
     <div style={{ opacity: animateOrderDisabled ? 0.3 : 1.0 }}>
       Order:{' '}
       {animateOrderSet.size > 1 ? (
-        <>(mixed)</>
+        <span style={{ opacity: 0.5 }}>
+              (Mixed values – cannot edit)
+        </span>
       ) : (
         <input
           className="app-input"
           type="number"
           disabled={animateOrderDisabled}
           value={
-            animateOrderSet.size === 1
-              ? animateOrderSet.values().next().value
-              : 0
+            (animateOrderSet.size === 1 &&
+              animateOrderSet.values().next().value) ||
+            0
           }
           onChange={onChangeAnimateOrder}
           style={{ width: 50, minWidth: 50 }}
@@ -178,16 +180,18 @@ export const AnimateConfig = ({
     <div style={{ opacity: animateDurationDisabled ? 0.3 : 1.0 }}>
       Duration:{' '}
       {animateDurationSet.size > 1 ? (
-        <>(mixed)</>
+        <span style={{ opacity: 0.5 }}>
+              (Mixed values – cannot edit)
+        </span>
       ) : (
         <>
           <input
             className="app-input"
             disabled={animateDurationDisabled}
             value={
-              animateDurationSet.size === 1
-                ? animateDurationSet.values().next().value
-                : ''
+              (animateDurationSet.size === 1 &&
+                animateDurationSet.values().next().value) ||
+              ''
             }
             onChange={onChangeAnimateDuration}
             placeholder="Default"
@@ -208,7 +212,7 @@ export const AnimateConfig = ({
           className="app-input"
           defaultValue={defaultAnimateOptions.pointerImg || ''}
           onChange={onChangeAnimatePointerText}
-          placeholder="URL..."
+          placeholder="Enter URL or choose a File..."
         />
         <input
           id="pointerFile"
@@ -225,7 +229,7 @@ export const AnimateConfig = ({
             alignItems: 'center',
           }}
         >
-          File
+          File...
         </label>
       </div>
 
@@ -235,7 +239,7 @@ export const AnimateConfig = ({
         className="app-input"
         defaultValue={defaultAnimateOptions.pointerWidth || ''}
         onChange={onChangeAnimatePointerWidth}
-        placeholder="Num..."
+        placeholder="Default"
         style={{ width: 50, minWidth: 50 }}
       />{' '}
       px

--- a/src/AnimateConfig.tsx
+++ b/src/AnimateConfig.tsx
@@ -142,17 +142,21 @@ export const AnimateConfig = ({
   const onChangeAnimatePointerWidth = (e: ChangeEvent<HTMLInputElement>) => {
     saveAnimateOption('pointerWidth', e.target.value);
   };
-return (
+  
+  return (
   <div
     style={{
       display: 'flex',
       flexDirection: 'column',
-      gap: 8,
+      gap: 12,
       fontSize: 14,
     }}
   >
+    {/* Animation Section */}
+    <div style={{ fontWeight: 'bold', marginBottom: 4 }}>Animation</div>
+
     <div style={{ opacity: animateOrderDisabled ? 0.3 : 1.0 }}>
-      Animate order:
+      Order:{' '}
       {animateOrderSet.size > 1 ? (
         <>(mixed)</>
       ) : (
@@ -172,27 +176,31 @@ return (
     </div>
 
     <div style={{ opacity: animateDurationDisabled ? 0.3 : 1.0 }}>
-      Animate duration (ms):
+      Duration:{' '}
       {animateDurationSet.size > 1 ? (
         <>(mixed)</>
       ) : (
-        <input
-          className="app-input"
-          disabled={animateDurationDisabled}
-          value={
-            animateDurationSet.size === 1
-              ? animateDurationSet.values().next().value
-              : ''
-          }
-          onChange={onChangeAnimateDuration}
-          placeholder="Default"
-          style={{ width: 50, minWidth: 50 }}
-        />
+        <>
+          <input
+            className="app-input"
+            disabled={animateDurationDisabled}
+            value={
+              animateDurationSet.size === 1
+                ? animateDurationSet.values().next().value
+                : ''
+            }
+            onChange={onChangeAnimateDuration}
+            placeholder="Default"
+            style={{ width: 50, minWidth: 50 }}
+          />{' '}
+          ms
+        </>
       )}
     </div>
 
-    <div style={{ display: 'grid', gap: 4 }}>
-      <div>Animate pointer:</div>
+      {/* Pointer Section */}
+      <div style={{ fontWeight: 'bold', margin: '8px 0 4px' }}>Pointer</div>
+
       <div
         style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 4 }}
       >
@@ -220,17 +228,17 @@ return (
           File
         </label>
       </div>
-    </div>
 
     <div>
-      Pointer width:
+      Width:{' '}
       <input
         className="app-input"
         defaultValue={defaultAnimateOptions.pointerWidth || ''}
         onChange={onChangeAnimatePointerWidth}
         placeholder="Num..."
         style={{ width: 50, minWidth: 50 }}
-      />
+      />{' '}
+      px
     </div>
   </div>
 );

--- a/src/AnimateConfig.tsx
+++ b/src/AnimateConfig.tsx
@@ -142,65 +142,61 @@ export const AnimateConfig = ({
   const onChangeAnimatePointerWidth = (e: ChangeEvent<HTMLInputElement>) => {
     saveAnimateOption('pointerWidth', e.target.value);
   };
-  
+
   return (
-  <div
-    style={{
-      display: 'flex',
-      flexDirection: 'column',
-      gap: 12,
-      fontSize: 14,
-    }}
-  >
-    {/* Animation Section */}
-    <div style={{ fontWeight: 'bold', marginBottom: 4 }}>Animation</div>
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 12,
+        fontSize: 14,
+      }}
+    >
+      {/* Animation Section */}
+      <div style={{ fontWeight: 'bold', marginBottom: 4 }}>Animation</div>
 
-    <div style={{ opacity: animateOrderDisabled ? 0.3 : 1.0 }}>
-      Order:{' '}
-      {animateOrderSet.size > 1 ? (
-        <span style={{ opacity: 0.5 }}>
-              (Mixed values – cannot edit)
-        </span>
-      ) : (
-        <input
-          className="app-input"
-          type="number"
-          disabled={animateOrderDisabled}
-          value={
-            (animateOrderSet.size === 1 &&
-              animateOrderSet.values().next().value) ||
-            0
-          }
-          onChange={onChangeAnimateOrder}
-          style={{ width: 50, minWidth: 50 }}
-        />
-      )}
-    </div>
-
-    <div style={{ opacity: animateDurationDisabled ? 0.3 : 1.0 }}>
-      Duration:{' '}
-      {animateDurationSet.size > 1 ? (
-        <span style={{ opacity: 0.5 }}>
-              (Mixed values – cannot edit)
-        </span>
-      ) : (
-        <>
+      <div style={{ opacity: animateOrderDisabled ? 0.3 : 1.0 }}>
+        Order:{' '}
+        {animateOrderSet.size > 1 ? (
+          <span style={{ opacity: 0.5 }}>(Mixed values – cannot edit)</span>
+        ) : (
           <input
             className="app-input"
-            disabled={animateDurationDisabled}
+            type="number"
+            disabled={animateOrderDisabled}
             value={
-              (animateDurationSet.size === 1 &&
-                animateDurationSet.values().next().value) ||
-              ''
+              (animateOrderSet.size === 1 &&
+                animateOrderSet.values().next().value) ||
+              0
             }
-            onChange={onChangeAnimateDuration}
-            placeholder="Default"
+            onChange={onChangeAnimateOrder}
             style={{ width: 50, minWidth: 50 }}
-          />{' '}
-          ms
-        </>
-      )}
-    </div>
+          />
+        )}
+      </div>
+
+      <div style={{ opacity: animateDurationDisabled ? 0.3 : 1.0 }}>
+        Duration:{' '}
+        {animateDurationSet.size > 1 ? (
+          <span style={{ opacity: 0.5 }}>(Mixed values – cannot edit)</span>
+        ) : (
+          <>
+            <input
+              className="app-input"
+              disabled={animateDurationDisabled}
+              value={
+                (animateDurationSet.size === 1 &&
+                  animateDurationSet.values().next().value) ||
+                ''
+              }
+              onChange={onChangeAnimateDuration}
+              placeholder="Default"
+              style={{ width: 50, minWidth: 50 }}
+            />{' '}
+            ms
+          </>
+        )}
+      </div>
 
       {/* Pointer Section */}
       <div style={{ fontWeight: 'bold', margin: '8px 0 4px' }}>Pointer</div>
@@ -233,17 +229,17 @@ export const AnimateConfig = ({
         </label>
       </div>
 
-    <div>
-      Width:{' '}
-      <input
-        className="app-input"
-        defaultValue={defaultAnimateOptions.pointerWidth || ''}
-        onChange={onChangeAnimatePointerWidth}
-        placeholder="Default"
-        style={{ width: 50, minWidth: 50 }}
-      />{' '}
-      px
+      <div>
+        Width:{' '}
+        <input
+          className="app-input"
+          defaultValue={defaultAnimateOptions.pointerWidth || ''}
+          onChange={onChangeAnimatePointerWidth}
+          placeholder="Default"
+          style={{ width: 50, minWidth: 50 }}
+        />{' '}
+        px
+      </div>
     </div>
-  </div>
-);
+  );
 };

--- a/src/AnimateConfig.tsx
+++ b/src/AnimateConfig.tsx
@@ -142,73 +142,96 @@ export const AnimateConfig = ({
   const onChangeAnimatePointerWidth = (e: ChangeEvent<HTMLInputElement>) => {
     saveAnimateOption('pointerWidth', e.target.value);
   };
-
-  return (
-    <div>
-      <div style={{ opacity: animateOrderDisabled ? 0.3 : 1.0 }}>
-        Animate order:{' '}
-        {animateOrderSet.size > 1 ? (
-          <>(mixed)</>
-        ) : (
-          <input
-            disabled={animateOrderDisabled}
-            value={
-              (animateOrderSet.size === 1 &&
-                animateOrderSet.values().next().value) ||
-              0
-            }
-            onChange={onChangeAnimateOrder}
-            type="number"
-            style={{ width: 40 }}
-          />
-        )}
-      </div>
-      <div style={{ opacity: animateDurationDisabled ? 0.3 : 1.0 }}>
-        Animate duration (ms):{' '}
-        {animateDurationSet.size > 1 ? (
-          <>(mixed)</>
-        ) : (
-          <input
-            disabled={animateDurationDisabled}
-            value={
-              (animateDurationSet.size === 1 &&
-                animateDurationSet.values().next().value) ||
-              ''
-            }
-            onChange={onChangeAnimateDuration}
-            placeholder="Default"
-            style={{ width: 50 }}
-          />
-        )}
-      </div>
-      <div>
-        Animate pointer:{' '}
+return (
+  <div
+    style={{
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 8,
+      fontSize: 14,
+    }}
+  >
+    <div style={{ opacity: animateOrderDisabled ? 0.3 : 1.0 }}>
+      Animate order:
+      {animateOrderSet.size > 1 ? (
+        <>(mixed)</>
+      ) : (
         <input
+          className="app-input"
+          type="number"
+          disabled={animateOrderDisabled}
+          value={
+            animateOrderSet.size === 1
+              ? animateOrderSet.values().next().value
+              : 0
+          }
+          onChange={onChangeAnimateOrder}
+          style={{ width: 50, minWidth: 50 }}
+        />
+      )}
+    </div>
+
+    <div style={{ opacity: animateDurationDisabled ? 0.3 : 1.0 }}>
+      Animate duration (ms):
+      {animateDurationSet.size > 1 ? (
+        <>(mixed)</>
+      ) : (
+        <input
+          className="app-input"
+          disabled={animateDurationDisabled}
+          value={
+            animateDurationSet.size === 1
+              ? animateDurationSet.values().next().value
+              : ''
+          }
+          onChange={onChangeAnimateDuration}
+          placeholder="Default"
+          style={{ width: 50, minWidth: 50 }}
+        />
+      )}
+    </div>
+
+    <div style={{ display: 'grid', gap: 4 }}>
+      <div>Animate pointer:</div>
+      <div
+        style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 4 }}
+      >
+        <input
+          className="app-input"
           defaultValue={defaultAnimateOptions.pointerImg || ''}
           onChange={onChangeAnimatePointerText}
           placeholder="URL..."
-          style={{ width: 50 }}
-        />{' '}
-        <label>
-          <input
-            type="file"
-            accept="image/*"
-            onChange={onChangeAnimatePointerFile}
-            style={{ width: 0 }}
-          />
+        />
+        <input
+          id="pointerFile"
+          type="file"
+          accept="image/*"
+          onChange={onChangeAnimatePointerFile}
+          style={{ display: 'none' }}
+        />
+        <label
+          htmlFor="pointerFile"
+          className="app-button"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+          }}
+        >
           File
         </label>
       </div>
-      <div>
-        (Pointer width:{' '}
-        <input
-          defaultValue={defaultAnimateOptions.pointerWidth || ''}
-          onChange={onChangeAnimatePointerWidth}
-          placeholder="Num..."
-          style={{ width: 50 }}
-        />
-        )
-      </div>
     </div>
-  );
+
+    <div>
+      Pointer width:
+      <input
+        className="app-input"
+        defaultValue={defaultAnimateOptions.pointerWidth || ''}
+        onChange={onChangeAnimatePointerWidth}
+        placeholder="Num..."
+        style={{ width: 50, minWidth: 50 }}
+      />
+    </div>
+  </div>
+);
 };

--- a/src/index.css
+++ b/src/index.css
@@ -102,7 +102,7 @@ code {
 /* Excalidraw styles: colors, size, border radius for outer DOM */
 .app-button {
   height: var(--lg-button-size);
-  padding: 0.625rem;
+  padding: 0 0.625rem;
   line-height: 0;
   background: var(--color-surface-low);
   border: none; /* Excalidraw often uses a 1px outline shadow instead of a border */


### PR DESCRIPTION
- Apply shared app-input and app-button style
- Add "Animation" / "Pointer" headings
- Show ms/px labels for Duration/Width
- Adjust placeholders 
- Update mixed state text

<img width="294" height="369" alt="90_animateConfg_ui" src="https://github.com/user-attachments/assets/4250bf2b-dff8-48a3-9138-d3ec98b70f36" />

<img width="293" height="356" alt="90_animateConfg_ui2" src="https://github.com/user-attachments/assets/70046f49-e0cf-4226-8548-3dccd6987c7a" />
