### PR TITLE
Fix: sidebar keeps disappearing after clicking outside

### DIFF
--- a/src/ExcalidrawApp.tsx
+++ b/src/ExcalidrawApp.tsx
@@ -49,7 +49,7 @@ const ExcalidrawApp = ({
           onChangeData({ elements, appState, files });
         }}
       >
-        <Sidebar name="custom">
+        <Sidebar name="custom" docked={true}>
           <Sidebar.Header />
           <div style={{ padding: '1rem' }}>
             {drawing && excalidrawAPI ? (


### PR DESCRIPTION
**Issue**: When you click on "Toggle Animate Panel" it shows a sidebar, but the sidebar keeps disappearing if you click anywhere else.

This will fix that.