### PR TITLE
feat: add tooltips for buttons and input fields

### DIFF
--- a/src/AnimateConfig.tsx
+++ b/src/AnimateConfig.tsx
@@ -172,6 +172,7 @@ export const AnimateConfig = ({
             }
             onChange={onChangeAnimateOrder}
             style={{ width: 50, minWidth: 50 }}
+            title="Set animation order"
           />
         )}
       </div>
@@ -193,6 +194,7 @@ export const AnimateConfig = ({
               onChange={onChangeAnimateDuration}
               placeholder="Default"
               style={{ width: 50, minWidth: 50 }}
+              title="Set animation duration in milliseconds"
             />{' '}
             ms
           </>
@@ -210,6 +212,7 @@ export const AnimateConfig = ({
           defaultValue={defaultAnimateOptions.pointerImg || ''}
           onChange={onChangeAnimatePointerText}
           placeholder="Enter URL or choose a File..."
+          title="Enter an image URL or choose a file for the pointer"
         />
         <input
           id="pointerFile"
@@ -225,6 +228,7 @@ export const AnimateConfig = ({
             display: 'inline-flex',
             alignItems: 'center',
           }}
+          title="Upload an image file for the pointer"
         >
           File...
         </label>
@@ -238,6 +242,7 @@ export const AnimateConfig = ({
           onChange={onChangeAnimatePointerWidth}
           placeholder="Default"
           style={{ width: 50, minWidth: 50 }}
+          title="Enter pointer width in pixels"
         />{' '}
         px
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,10 +67,24 @@ const App = () => {
           gap: 5,
         }}
       >
-        <button className="app-button app-button-compact" onClick={toggleMode}>
+        <button
+          className="app-button app-button-compact"
+          onClick={toggleMode}
+          title={
+            mode === 'animate'
+              ? 'Switch to edit mode'
+              : 'Switch to animate mode'
+          }
+        >
           {mode === 'animate' ? 'Edit' : 'Animate'}
         </button>
-        <button className="app-button app-button-compact" onClick={toggleTheme}>
+        <button
+          className="app-button app-button-compact"
+          onClick={toggleTheme}
+          title={
+            theme === 'light' ? 'Switch to dark mode' : 'Switch to light mode'
+          }
+        >
           {theme === 'light' ? '🌙' : '☀️'}
         </button>
       </div>

--- a/src/ExcalidrawApp.tsx
+++ b/src/ExcalidrawApp.tsx
@@ -66,6 +66,7 @@ const ExcalidrawApp = ({ initialData, onChangeData, theme }: Props) => {
             style={{
               marginLeft: '0.5rem',
             }}
+            title="Show or hide the Animate panel"
           >
             Toggle Animate Panel
           </Sidebar.Trigger>

--- a/src/GitHubCorner.tsx
+++ b/src/GitHubCorner.tsx
@@ -13,6 +13,7 @@ const GitHubCorner = ({ link, size, fill, color }: Props) => (
     aria-label="View source on GitHub"
     target="_blank"
     rel="noopener noreferrer"
+    title="View source on GitHub"
   >
     <svg
       width={size || 80}

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -254,14 +254,19 @@ const Toolbar = ({ svgList, loadDataList, theme }: Props) => {
   const Toggle = ({
     checked,
     onChange,
+    ariaLabel,
+    title,
   }: {
     checked: boolean;
     onChange: () => void;
     ariaLabel: string;
+    title: string;
   }) => (
     <button
       type="button"
       onClick={onChange}
+      aria-label={ariaLabel}
+      title={title}
       style={{
         position: 'relative',
         width: 52,
@@ -296,11 +301,21 @@ const Toolbar = ({ svgList, loadDataList, theme }: Props) => {
         <div
           className={`toolbar ${showToolbar === true ? '' : 'toolbar--hidden'}`}
         >
-          <button type="button" onClick={loadFile} className="app-button">
+          <button
+            type="button"
+            onClick={loadFile}
+            className="app-button"
+            title="Load Excalidraw file (.json)"
+          >
             Load File
           </button>
           <span>OR</span>
-          <button type="button" onClick={loadLibrary} className="app-button">
+          <button
+            type="button"
+            onClick={loadLibrary}
+            className="app-button"
+            title="Load Excalidraw library file (.excalidrawlib)"
+          >
             Load Library
           </button>
           <span>OR</span>
@@ -309,11 +324,13 @@ const Toolbar = ({ svgList, loadDataList, theme }: Props) => {
               className="app-input"
               placeholder="Enter link..."
               value={link}
+              title="Enter #json= link or .excalidrawlib URL"
               onChange={(e) => setLink(e.target.value)}
             />
             <button
               type="submit"
               disabled={!linkRegex.test(link)}
+              title="Animate the loaded SVG"
               className="app-button"
             >
               Animate!
@@ -326,6 +343,11 @@ const Toolbar = ({ svgList, loadDataList, theme }: Props) => {
               type="button"
               onClick={togglePausedAnimations}
               className="app-button"
+              title={
+                paused
+                  ? 'Play animation (shortcut: P)'
+                  : 'Pause animation (shortcut: P)'
+              }
             >
               {paused ? 'Play (P)' : 'Pause (P)'}
             </button>
@@ -333,6 +355,7 @@ const Toolbar = ({ svgList, loadDataList, theme }: Props) => {
               type="button"
               onClick={stepForwardAnimations}
               className="app-button"
+              title="Advance animation to next step (shortcut: S)"
             >
               Step (S)
             </button>
@@ -340,10 +363,16 @@ const Toolbar = ({ svgList, loadDataList, theme }: Props) => {
               type="button"
               onClick={resetAnimations}
               className="app-button"
+              title="Restart animation from beginning (shortcut: R)"
             >
               Reset (R)
             </button>
-            <button type="button" onClick={hideToolbar} className="app-button">
+            <button
+              type="button"
+              onClick={hideToolbar}
+              className="app-button"
+              title="Hide toolbar (shortcut: Q)"
+            >
               Hide Toolbar (Q)
             </button>
             <button
@@ -353,6 +382,7 @@ const Toolbar = ({ svgList, loadDataList, theme }: Props) => {
                 setShowExport(true);
               }}
               className="app-button"
+              title="Export current animation as SVG file"
             >
               Export to SVG
             </button>
@@ -361,6 +391,11 @@ const Toolbar = ({ svgList, loadDataList, theme }: Props) => {
               onClick={exportToWebm}
               disabled={processing}
               className="app-button"
+              title={
+                webmData
+                  ? 'Export animation as WebM video file'
+                  : 'Prepare animation for WebM export'
+              }
             >
               {processing
                 ? 'Processing...'
@@ -401,6 +436,11 @@ const Toolbar = ({ svgList, loadDataList, theme }: Props) => {
                 checked={exportBackground}
                 onChange={() => setExportBackground(!exportBackground)}
                 ariaLabel="Toggle background"
+                title={
+                  exportBackground
+                    ? 'Background enabled'
+                    : 'Background disabled'
+                }
               />
             </div>
             <div className="modal-row">
@@ -411,6 +451,7 @@ const Toolbar = ({ svgList, loadDataList, theme }: Props) => {
                   setExportTheme(exportTheme === 'dark' ? 'light' : 'dark')
                 }
                 ariaLabel="Toggle dark mode"
+                title={exportTheme === 'dark' ? 'Dark mode' : 'Light mode'}
               />
             </div>
             <div className="modal-footer">
@@ -422,6 +463,7 @@ const Toolbar = ({ svgList, loadDataList, theme }: Props) => {
                   exportToSvg();
                   setShowExport(false);
                 }}
+                title="Export with current settings to SVG"
               >
                 Export
               </button>


### PR DESCRIPTION
- Add tooltips in Animate/Edit page, AnimateConfig inputs and export modal
- Improve clarity for animation controls and export settings

Note: Tooltips are not shown when buttons are disabled (browser default behavior)

<img width="588" height="178" alt="97_tooltips" src="https://github.com/user-attachments/assets/13c237fa-f28f-428d-ab9f-b87fd7229137" />