### PR TITLE
feat: add Modal component and show error modal on file/library load failure

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+interface ModalProps {
+  title: string;
+  children: React.ReactNode;
+  onClose?: () => void;
+  footerLabel?: string;
+  footerTitle?: string;
+  onFooterClick?: () => void;
+}
+
+export const Modal = ({
+  title,
+  children,
+  onClose,
+  footerLabel,
+  footerTitle,
+  onFooterClick,
+}: ModalProps) => {
+  return (
+    <div
+      role="presentation"
+      className="modal-overlay"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && onClose) onClose();
+      }}
+    >
+      <div role="dialog" className="modal-panel">
+        <h3
+          style={{
+            margin: 0,
+            marginBottom: '0.75rem',
+            fontWeight: 800,
+            fontSize: '1.1rem',
+            textAlign: 'left',
+          }}
+        >
+          {title}
+        </h3>
+        <div className="modal-body">{children}</div>
+        {footerLabel && (
+          <div className="modal-footer">
+            <button
+              type="button"
+              className="app-button app-button--primary"
+              onClick={onFooterClick || onClose}
+              title={footerTitle}
+            >
+              {footerLabel}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
* Create a reusable Modal component and applied it to the “Export to SVG” dialog
* Add error handling for file and library loading, showing an error modal when loading fails

Note: Appearance to match the original Excalidraw UI

<img width="516" height="256" alt="error_modal1" src="https://github.com/user-attachments/assets/46086d7e-9ce7-448c-a5cf-d0a547d1a898" />
<img width="471" height="222" alt="error_modal2" src="https://github.com/user-attachments/assets/b04be96c-4576-4ebe-949c-2b94f614d0e3" />
