### PR TITLE
style: adjust dark mode contrast for File... button in AnimateConfig

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -179,6 +179,12 @@ code {
   background: var(--button-active-bg);
 }
 
+/* Dark mode: brighten only the 'File...' button in AnimateConfig for better contrast */
+:root.dark .excalidraw .animate-config label[for='pointerFile'].app-button {
+  background: hsl(240 8% 20%);
+  box-shadow: 0 0 0 1px hsl(240 8% 25%);
+}
+
 .app-input {
   height: var(--lg-button-size);
   box-sizing: border-box;


### PR DESCRIPTION
- Adjust dark mode contrast for the “File…” button in AnimateConfig.
- The button looked slightly dim against the dark side panel background due to fallback variable definitions in index.css. Added a slightly lighter background and subtle outline for better consistency.

<img width="685" height="234" alt="101_dark_mode_button" src="https://github.com/user-attachments/assets/8a803ce8-4857-4b0a-aa25-7a3768bed954" />
