### PR TITLE
fix: filter image elements with missing file data to prevent element …

### DIFF
--- a/src/useLoadSvg.ts
+++ b/src/useLoadSvg.ts
@@ -98,7 +98,11 @@ export const useLoadSvg = (
       };
       const svgList = await Promise.all(
         dataList.map(async (data) => {
-          const elements = getNonDeletedElements(data.elements);
+          const elements = getNonDeletedElements(data.elements).filter((el) => {
+            if (el.type !== 'image') return true;
+            const fileId = (el as { fileId?: string | null }).fileId;
+            return fileId != null && data.files[fileId] != null;
+          });
           const svg = await exportToSvg({
             elements,
             files: data.files,


### PR DESCRIPTION
…length mismatch

Problem:
When loading from shared link, files is always empty because loadScene only fetches elements and appState from the backend, not the binary file data for images. If a diagram has image elements, exportToSvg skips them (no <g> node generated), causing a count mismatch with elements and throwing "element length mismatch".

Note: this does not happen with local drawings, as files always has the embedded data.

Fix:
Filter out image elements with missing file data before calling animateSvg, so the element count matches the SVG node count.

Fixes #43