### PR TITLE
Animate Panel v2

### DIFF
--- a/e2e/animate-config.spec.ts
+++ b/e2e/animate-config.spec.ts
@@ -25,7 +25,7 @@ async function openAnimatePanel(page: Page) {
       const triggers = document.querySelectorAll('.sidebar-trigger');
       triggers.forEach((trigger) => {
         const label = trigger.querySelector('.sidebar-trigger__label');
-        if (label && label.textContent?.includes('Toggle Animate Panel')) {
+        if (label && label.textContent?.trim() === 'Toggle Animate Panel') {
           (trigger as HTMLElement).click();
         }
       });

--- a/src/AnimateConfigV2.tsx
+++ b/src/AnimateConfigV2.tsx
@@ -1,0 +1,308 @@
+import { useEffect, useRef } from 'react';
+import type {
+  ExcalidrawImperativeAPI,
+} from '@excalidraw/excalidraw/types';
+import type { ExcalidrawElement } from '@excalidraw/excalidraw/element/types';
+
+import type { Drawing } from './AnimateConfig';
+
+const extractOrder = (id: string): number => {
+  const match = id.match(/animateOrder:(-?\d+)/);
+  return match ? Number(match[1]) : 0;
+};
+
+const extractDuration = (id: string): number | undefined => {
+  const match = id.match(/animateDuration:(-?\d+)/);
+  return match ? Number(match[1]) : undefined;
+};
+
+const setOrderInId = (id: string, order: number): string => {
+  if (/animateOrder:(-?\d+)/.test(id)) {
+    return id.replace(/animateOrder:(-?\d+)/, `animateOrder:${order}`);
+  }
+  return `${id}-animateOrder:${order}`;
+};
+
+const setDurationInId = (id: string, duration: number): string => {
+  if (/animateDuration:(-?\d+)/.test(id)) {
+    return id.replace(/animateDuration:(-?\d+)/, `animateDuration:${duration}`);
+  }
+  return `${id}-animateDuration:${duration}`;
+};
+
+const getBaseId = (id: string): string =>
+  id.replace(/-animateOrder:-?\d+/g, '').replace(/-animateDuration:-?\d+/g, '');
+
+const GROUP_COLORS = [
+  '#f97316', '#3b82f6', '#22c55e', '#a855f7',
+  '#eab308', '#ec4899', '#14b8a6', '#ef4444',
+];
+
+const getGroupColor = (groupId: string): string => {
+  let hash = 0;
+  for (let i = 0; i < groupId.length; i++) {
+    hash = (hash * 31 + groupId.charCodeAt(i)) & 0xffffff;
+  }
+  return GROUP_COLORS[Math.abs(hash) % GROUP_COLORS.length];
+};
+
+const getElementLabel = (element: ExcalidrawElement): string => {
+  if (element.type === 'text') {
+    const text = (element as { text?: string }).text ?? '';
+    const trimmed = text.replace(/\s+/g, ' ').trim();
+    return trimmed.length > 22 ? trimmed.slice(0, 22) + '...' : trimmed || 'text';
+  }
+  const shortId = getBaseId(element.id).slice(0, 6);
+  return `${element.type} [${shortId}]`;
+};
+
+// Returns the contiguous block bounds for the element at `index`.
+// Elements sharing the same primary groupId that are adjacent form one block.
+const getBlockContaining = (
+  elems: ExcalidrawElement[],
+  index: number,
+): { start: number; end: number } => {
+  const groupId = elems[index].groupIds?.[0];
+  if (!groupId) return { start: index, end: index };
+  let start = index;
+  while (start > 0 && elems[start - 1].groupIds?.[0] === groupId) start--;
+  let end = index;
+  while (end < elems.length - 1 && elems[end + 1].groupIds?.[0] === groupId) end++;
+  return { start, end };
+};
+
+type Props = {
+  drawing: Drawing;
+  api: ExcalidrawImperativeAPI;
+};
+
+export const AnimateConfigV2 = ({ drawing, api }: Props) => {
+  const allElements = drawing.elements.filter((el) => !el.isDeleted);
+
+  const sorted = [...allElements].sort((a, b) => {
+    const diff = extractOrder(a.id) - extractOrder(b.id);
+    if (diff !== 0) return diff;
+    return drawing.elements.indexOf(a) - drawing.elements.indexOf(b);
+  });
+
+  const selectedIds = drawing.appState.selectedElementIds ?? {};
+
+  const rowRefMap = useRef<Map<string, HTMLDivElement>>(new Map());
+  const sortedRef = useRef(sorted);
+  sortedRef.current = sorted;
+
+  useEffect(() => {
+    const firstSelected = sortedRef.current.find((el) => selectedIds[el.id]);
+    if (firstSelected) {
+      const node = rowRefMap.current.get(firstSelected.id);
+      if (node) {
+        node.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [drawing.appState.selectedElementIds]);
+
+  const applyNewOrder = (newOrder: ExcalidrawElement[]) => {
+    const idToNewOrder = new Map<string, number>();
+    newOrder.forEach((el, i) => idToNewOrder.set(el.id, i));
+
+    const oldToNew = new Map<string, string>();
+    const elements = drawing.elements.map((el) => {
+      if (el.isDeleted) return el;
+      const newIdx = idToNewOrder.get(el.id);
+      if (newIdx === undefined) return el;
+      const newId = setOrderInId(el.id, newIdx);
+      if (newId !== el.id) oldToNew.set(el.id, newId);
+      return newId !== el.id ? { ...el, id: newId } : el;
+    });
+
+    const updatedSelectedIds = { ...drawing.appState.selectedElementIds };
+    oldToNew.forEach((newId, oldId) => {
+      if (updatedSelectedIds[oldId]) {
+        updatedSelectedIds[newId] = updatedSelectedIds[oldId];
+        delete updatedSelectedIds[oldId];
+      }
+    });
+
+    api.updateScene({
+      elements,
+      appState: { ...drawing.appState, selectedElementIds: updatedSelectedIds },
+      files: drawing.files,
+    });
+  };
+
+  // Moves the entire block containing `fromIndex` up or down one block.
+  const moveBlock = (fromIndex: number, direction: 'up' | 'down') => {
+    const block = getBlockContaining(sorted, fromIndex);
+
+    if (direction === 'up') {
+      if (block.start === 0) return;
+      const above = getBlockContaining(sorted, block.start - 1);
+      const newOrder = [...sorted];
+      const moved = newOrder.splice(block.start, block.end - block.start + 1);
+      newOrder.splice(above.start, 0, ...moved);
+      applyNewOrder(newOrder);
+    } else {
+      if (block.end >= sorted.length - 1) return;
+      const below = getBlockContaining(sorted, block.end + 1);
+      const blockSize = block.end - block.start + 1;
+      const newOrder = [...sorted];
+      const moved = newOrder.splice(block.start, blockSize);
+      // After removing the block, below.end shifts left by blockSize
+      newOrder.splice(below.end - blockSize + 1, 0, ...moved);
+      applyNewOrder(newOrder);
+    }
+  };
+
+  const selectElement = (element: ExcalidrawElement) => {
+    const primaryGroupId = element.groupIds?.[0];
+    const newSelectedIds: Record<string, true> = {};
+
+    if (primaryGroupId) {
+      drawing.elements.forEach((el) => {
+        if (!el.isDeleted && el.groupIds?.includes(primaryGroupId)) {
+          newSelectedIds[el.id] = true;
+        }
+      });
+    } else {
+      newSelectedIds[element.id] = true;
+    }
+
+    api.updateScene({
+      appState: { ...drawing.appState, selectedElementIds: newSelectedIds },
+    });
+  };
+
+  const setDuration = (elementId: string, duration: number) => {
+    const oldToNew = new Map<string, string>();
+    const elements = drawing.elements.map((el) => {
+      if (el.id !== elementId) return el;
+      const newId = setDurationInId(el.id, duration);
+      if (newId !== el.id) oldToNew.set(el.id, newId);
+      return newId !== el.id ? { ...el, id: newId } : el;
+    });
+
+    const updatedSelectedIds = { ...drawing.appState.selectedElementIds };
+    oldToNew.forEach((newId, oldId) => {
+      if (updatedSelectedIds[oldId]) {
+        updatedSelectedIds[newId] = updatedSelectedIds[oldId];
+        delete updatedSelectedIds[oldId];
+      }
+    });
+
+    api.updateScene({
+      elements,
+      appState: { ...drawing.appState, selectedElementIds: updatedSelectedIds },
+      files: drawing.files,
+    });
+  };
+
+  if (sorted.length === 0) {
+    return (
+      <div style={{ color: 'gray', fontSize: 13 }}>No elements on canvas.</div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden', fontSize: 13 }}>
+      <div
+        style={{
+          fontWeight: 'bold',
+          marginBottom: 6,
+          borderBottom: '1px solid gray',
+          paddingBottom: 5,
+          flexShrink: 0,
+        }}
+      >
+        Animation Order
+      </div>
+      <div style={{ flex: 1, overflowY: 'auto', minHeight: 0 }}>
+        {sorted.map((element, i) => {
+          const duration = extractDuration(element.id);
+          const isSelected = !!selectedIds[element.id];
+          const primaryGroupId = element.groupIds?.[0];
+          const groupColor = primaryGroupId ? getGroupColor(primaryGroupId) : undefined;
+          const block = getBlockContaining(sorted, i);
+          return (
+            <div
+              key={element.id}
+              ref={(node) => {
+                if (node) rowRefMap.current.set(element.id, node);
+                else rowRefMap.current.delete(element.id);
+              }}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 4,
+                padding: '3px 4px',
+                paddingLeft: groupColor ? 2 : 4,
+                borderRadius: 4,
+                borderLeft: groupColor ? `3px solid ${groupColor}` : '3px solid transparent',
+                backgroundColor: isSelected ? 'rgba(100, 130, 255, 0.18)' : 'transparent',
+              }}
+            >
+              <span
+                style={{
+                  width: 18,
+                  textAlign: 'right',
+                  color: 'gray',
+                  flexShrink: 0,
+                  fontSize: 11,
+                }}
+              >
+                {i + 1}.
+              </span>
+              <span
+                style={{
+                  flex: 1,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  minWidth: 0,
+                  fontWeight: isSelected ? 'bold' : 'normal',
+                  cursor: 'pointer',
+                }}
+                title={getElementLabel(element)}
+                onClick={() => selectElement(element)}
+              >
+                {getElementLabel(element)}
+              </span>
+              <button
+                className="app-button"
+                style={{ padding: '1px 5px', fontSize: 11, flexShrink: 0 }}
+                disabled={block.start === 0}
+                title="Move up"
+                onClick={() => moveBlock(i, 'up')}
+              >
+                ^
+              </button>
+              <button
+                className="app-button"
+                style={{ padding: '1px 5px', fontSize: 11, flexShrink: 0 }}
+                disabled={block.end === sorted.length - 1}
+                title="Move down"
+                onClick={() => moveBlock(i, 'down')}
+              >
+                v
+              </button>
+              <input
+                className="app-input"
+                type="number"
+                defaultValue={duration ?? ''}
+                placeholder="ms"
+                style={{ width: 52, minWidth: 52, flexShrink: 0, fontSize: 11 }}
+                title="Duration in milliseconds"
+                onBlur={(e) => {
+                  const val = Math.floor(Number(e.currentTarget.value));
+                  if (Number.isFinite(val) && val > 0) {
+                    setDuration(element.id, val);
+                  }
+                }}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/src/AnimateConfigV2.tsx
+++ b/src/AnimateConfigV2.tsx
@@ -5,6 +5,7 @@ import type {
 import type { ExcalidrawElement } from '@excalidraw/excalidraw/element/types';
 
 import type { Drawing } from './AnimateConfig';
+import { Modal } from './Modal';
 
 const extractOrder = (id: string): number | undefined => {
   const match = id.match(/animateOrder:(-?\d+)/);
@@ -106,15 +107,16 @@ export const AnimateConfigV2 = ({ drawing, api }: Props) => {
   const blocks = computeBlocks(sorted);
 
   const selectedIds = drawing.appState.selectedElementIds ?? {};
+  const selectedCount = sorted.filter((el) => selectedIds[el.id]).length;
 
   const rowRefMap = useRef<Map<string, HTMLDivElement>>(new Map());
   const sortedRef = useRef(sorted);
   sortedRef.current = sorted;
 
-  // dragBlockIdx: index in `blocks` of the block being dragged
-  // dropBlockIdx: insert dragged block BEFORE this block index (0..blocks.length)
   const [dragBlockIdx, setDragBlockIdx] = useState<number | null>(null);
   const [dropBlockIdx, setDropBlockIdx] = useState<number | null>(null);
+  const [batchDuration, setBatchDuration] = useState('');
+  const [showHelp, setShowHelp] = useState(false);
 
   useEffect(() => {
     const firstSelected = sortedRef.current.find((el) => selectedIds[el.id]);
@@ -156,6 +158,41 @@ export const AnimateConfigV2 = ({ drawing, api }: Props) => {
     });
   };
 
+  const applyBatchDuration = () => {
+    const val = Math.floor(Number(batchDuration));
+    if (!Number.isFinite(val) || val <= 0) return;
+
+    const targets = new Set(
+      selectedCount > 0
+        ? sorted.filter((el) => selectedIds[el.id]).map((el) => el.id)
+        : sorted.map((el) => el.id),
+    );
+
+    const oldToNew = new Map<string, string>();
+    const elements = drawing.elements.map((el) => {
+      if (el.isDeleted || !targets.has(el.id)) return el;
+      const newId = setDurationInId(el.id, val);
+      if (newId !== el.id) oldToNew.set(el.id, newId);
+      return newId !== el.id ? { ...el, id: newId } : el;
+    });
+
+    const updatedSelectedIds = { ...drawing.appState.selectedElementIds };
+    oldToNew.forEach((newId, oldId) => {
+      if (updatedSelectedIds[oldId]) {
+        updatedSelectedIds[newId] = updatedSelectedIds[oldId];
+        delete updatedSelectedIds[oldId];
+      }
+    });
+
+    api.updateScene({
+      elements,
+      appState: { ...drawing.appState, selectedElementIds: updatedSelectedIds },
+      files: drawing.files,
+    });
+
+    setBatchDuration('');
+  };
+
   const handleDragStart = (e: React.DragEvent<HTMLDivElement>, blockIdx: number) => {
     e.dataTransfer.effectAllowed = 'move';
     setDragBlockIdx(blockIdx);
@@ -177,7 +214,6 @@ export const AnimateConfigV2 = ({ drawing, api }: Props) => {
       setDropBlockIdx(null);
       return;
     }
-    // No-op: dropping adjacent to itself
     if (dropBlockIdx === dragBlockIdx || dropBlockIdx === dragBlockIdx + 1) {
       setDragBlockIdx(null);
       setDropBlockIdx(null);
@@ -212,23 +248,38 @@ export const AnimateConfigV2 = ({ drawing, api }: Props) => {
     setDropBlockIdx(null);
   };
 
-  const selectElement = (element: ExcalidrawElement) => {
+  const selectElement = (element: ExcalidrawElement, shiftHeld: boolean) => {
     const primaryGroupId = element.groupIds?.[0];
-    const newSelectedIds: Record<string, true> = {};
+    const clickedIds: string[] = [];
 
     if (primaryGroupId) {
       drawing.elements.forEach((el) => {
         if (!el.isDeleted && el.groupIds?.includes(primaryGroupId)) {
-          newSelectedIds[el.id] = true;
+          clickedIds.push(el.id);
         }
       });
     } else {
-      newSelectedIds[element.id] = true;
+      clickedIds.push(element.id);
     }
 
-    api.updateScene({
-      appState: { ...drawing.appState, selectedElementIds: newSelectedIds },
-    });
+    if (shiftHeld) {
+      const isAlreadySelected = !!selectedIds[element.id];
+      const updatedSelectedIds = { ...selectedIds };
+      if (isAlreadySelected) {
+        clickedIds.forEach((id) => { delete updatedSelectedIds[id]; });
+      } else {
+        clickedIds.forEach((id) => { updatedSelectedIds[id] = true; });
+      }
+      api.updateScene({
+        appState: { ...drawing.appState, selectedElementIds: updatedSelectedIds },
+      });
+    } else {
+      const newSelectedIds: Record<string, true> = {};
+      clickedIds.forEach((id) => { newSelectedIds[id] = true; });
+      api.updateScene({
+        appState: { ...drawing.appState, selectedElementIds: newSelectedIds },
+      });
+    }
   };
 
   const setDuration = (elementId: string, duration: number) => {
@@ -262,113 +313,201 @@ export const AnimateConfigV2 = ({ drawing, api }: Props) => {
   }
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden', fontSize: 13 }}>
-      <div
-        style={{
-          fontWeight: 'bold',
-          marginBottom: 6,
-          borderBottom: '1px solid gray',
-          paddingBottom: 5,
-          flexShrink: 0,
-        }}
-      >
-        Animation Order
-      </div>
-      <div
-        style={{ flex: 1, overflowY: 'auto', minHeight: 0 }}
-        onDragLeave={(e) => {
-          if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-            setDropBlockIdx(null);
-          }
-        }}
-      >
-        {sorted.map((element, i) => {
-          const duration = extractDuration(element.id);
-          const isSelected = !!selectedIds[element.id];
-          const primaryGroupId = element.groupIds?.[0];
-          const groupColor = primaryGroupId ? getGroupColor(primaryGroupId) : undefined;
-          const blockIdx = blocks.findIndex((b) => i >= b.start && i <= b.end);
-          const isDragged = dragBlockIdx !== null && blockIdx === dragBlockIdx;
-          const showIndicatorBefore =
-            dropBlockIdx !== null &&
-            dropBlockIdx < blocks.length &&
-            blocks[dropBlockIdx].start === i;
-          const showIndicatorAfter =
-            dropBlockIdx === blocks.length && i === sorted.length - 1;
+    <>
+      {showHelp && (
+        <Modal
+          title="Animate Panel v2 - Help"
+          onClose={() => setShowHelp(false)}
+          footerLabel="Close"
+          onFooterClick={() => setShowHelp(false)}
+        >
+          <div style={{ fontSize: 13, lineHeight: 1.6, display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <p style={{ margin: 0 }}>
+              <strong>Reorder:</strong> Drag a row by its grip handle (dotted area on the left).
+              Grouped elements always move together as a block.
+            </p>
+            <p style={{ margin: 0 }}>
+              <strong>Select:</strong> Click an element name to select it on the canvas.
+              Clicking any member of a group selects the whole group.
+              Hold Shift and click to add items to the current selection, or to remove an
+              already-selected item from it.
+            </p>
+            <p style={{ margin: 0 }}>
+              <strong>Duration:</strong> The number input on the right of each row sets that
+              element's animation duration in milliseconds. Values shown in gray are defaults
+              computed from the animation engine.
+            </p>
+            <p style={{ margin: 0 }}>
+              <strong>Batch duration:</strong> Enter a value in the "Set duration" field and
+              click Apply. If elements are selected on the canvas, only those are updated;
+              otherwise all elements are updated.
+            </p>
+            <p style={{ margin: 0 }}>
+              <strong>Groups:</strong> The colored bar on the left edge of a row indicates
+              the element belongs to a group. Rows sharing the same color are in the same group.
+            </p>
+            <p style={{ margin: 0 }}>
+              <strong>New elements:</strong> Elements added to the canvas appear at the bottom
+              of the list with no explicit order set. Drag them into position to fix their order.
+            </p>
+          </div>
+        </Modal>
+      )}
+      <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden', fontSize: 13 }}>
+        {/* Header */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            marginBottom: 6,
+            borderBottom: '1px solid gray',
+            paddingBottom: 5,
+            flexShrink: 0,
+          }}
+        >
+          <span style={{ fontWeight: 'bold' }}>Animation Order</span>
+          <button
+            className="app-button"
+            style={{ width: 22, height: 22, padding: 0, fontSize: 13, borderRadius: '50%', flexShrink: 0 }}
+            title="Help"
+            onClick={() => setShowHelp(true)}
+          >
+            ?
+          </button>
+        </div>
 
-          return (
-            <div
-              key={element.id}
-              ref={(node) => {
-                if (node) rowRefMap.current.set(element.id, node);
-                else rowRefMap.current.delete(element.id);
-              }}
-              onDragOver={(e) => handleDragOver(e, i)}
-              onDrop={handleDrop}
-              onDragEnd={handleDragEnd}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 4,
-                padding: '3px 4px',
-                paddingLeft: groupColor ? 2 : 4,
-                borderRadius: 4,
-                borderLeft: groupColor ? `3px solid ${groupColor}` : '3px solid transparent',
-                borderTop: showIndicatorBefore ? '2px solid #4a90e2' : '2px solid transparent',
-                borderBottom: showIndicatorAfter ? '2px solid #4a90e2' : '2px solid transparent',
-                backgroundColor: isSelected ? 'rgba(100, 130, 255, 0.18)' : 'transparent',
-                opacity: isDragged ? 0.4 : 1,
-              }}
-            >
+        {/* Batch duration toolbar */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            marginBottom: 8,
+            flexShrink: 0,
+          }}
+        >
+          <span style={{ color: 'gray', whiteSpace: 'nowrap' }}>Set duration:</span>
+          <input
+            className="app-input"
+            type="number"
+            value={batchDuration}
+            placeholder="ms"
+            style={{ flex: 1, minWidth: 0 }}
+            onChange={(e) => setBatchDuration(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') applyBatchDuration(); }}
+          />
+          <button
+            className="app-button"
+            style={{ whiteSpace: 'nowrap', flexShrink: 0 }}
+            title={
+              selectedCount > 0
+                ? `Apply to ${selectedCount} selected element${selectedCount > 1 ? 's' : ''}`
+                : `Apply to all ${sorted.length} elements`
+            }
+            onClick={applyBatchDuration}
+          >
+            {selectedCount > 0 ? `Apply (${selectedCount})` : `Apply (all)`}
+          </button>
+        </div>
+
+        {/* List */}
+        <div
+          style={{ flex: 1, overflowY: 'auto', minHeight: 0 }}
+          onDragLeave={(e) => {
+            if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+              setDropBlockIdx(null);
+            }
+          }}
+        >
+          {sorted.map((element, i) => {
+            const duration = extractDuration(element.id);
+            const isSelected = !!selectedIds[element.id];
+            const primaryGroupId = element.groupIds?.[0];
+            const groupColor = primaryGroupId ? getGroupColor(primaryGroupId) : undefined;
+            const blockIdx = blocks.findIndex((b) => i >= b.start && i <= b.end);
+            const isDragged = dragBlockIdx !== null && blockIdx === dragBlockIdx;
+            const showIndicatorBefore =
+              dropBlockIdx !== null &&
+              dropBlockIdx < blocks.length &&
+              blocks[dropBlockIdx].start === i;
+            const showIndicatorAfter =
+              dropBlockIdx === blocks.length && i === sorted.length - 1;
+
+            return (
               <div
-                className="drag-handle"
-                draggable
-                onDragStart={(e) => handleDragStart(e, blockIdx)}
-              />
-              <span
+                key={element.id}
+                ref={(node) => {
+                  if (node) rowRefMap.current.set(element.id, node);
+                  else rowRefMap.current.delete(element.id);
+                }}
+                onDragOver={(e) => handleDragOver(e, i)}
+                onDrop={handleDrop}
+                onDragEnd={handleDragEnd}
                 style={{
-                  width: 18,
-                  textAlign: 'right',
-                  color: 'gray',
-                  flexShrink: 0,
-                  fontSize: 11,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 4,
+                  padding: '3px 4px',
+                  paddingLeft: groupColor ? 2 : 4,
+                  borderRadius: 4,
+                  borderLeft: groupColor ? `3px solid ${groupColor}` : '3px solid transparent',
+                  borderTop: showIndicatorBefore ? '2px solid #4a90e2' : '2px solid transparent',
+                  borderBottom: showIndicatorAfter ? '2px solid #4a90e2' : '2px solid transparent',
+                  backgroundColor: isSelected ? 'rgba(100, 130, 255, 0.18)' : 'transparent',
+                  opacity: isDragged ? 0.4 : 1,
                 }}
               >
-                {i + 1}.
-              </span>
-              <span
-                style={{
-                  flex: 1,
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                  minWidth: 0,
-                  fontWeight: isSelected ? 'bold' : 'normal',
-                  cursor: 'pointer',
-                }}
-                title={getElementLabel(element)}
-                onClick={() => selectElement(element)}
-              >
-                {getElementLabel(element)}
-              </span>
-              <input
-                className="app-input"
-                type="number"
-                defaultValue={duration ?? getDefaultDuration(element, allElements)}
-                placeholder="ms"
-                style={{ width: 52, minWidth: 52, flexShrink: 0, fontSize: 11 }}
-                title="Duration in milliseconds"
-                onBlur={(e) => {
-                  const val = Math.floor(Number(e.currentTarget.value));
-                  if (Number.isFinite(val) && val > 0) {
-                    setDuration(element.id, val);
-                  }
-                }}
-              />
-            </div>
-          );
-        })}
+                <div
+                  className="drag-handle"
+                  draggable
+                  onDragStart={(e) => handleDragStart(e, blockIdx)}
+                />
+                <span
+                  style={{
+                    width: 18,
+                    textAlign: 'right',
+                    color: 'gray',
+                    flexShrink: 0,
+                    fontSize: 11,
+                  }}
+                >
+                  {i + 1}.
+                </span>
+                <span
+                  style={{
+                    flex: 1,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    minWidth: 0,
+                    fontWeight: isSelected ? 'bold' : 'normal',
+                    cursor: 'pointer',
+                  }}
+                  title={getElementLabel(element)}
+                  onClick={(e) => selectElement(element, e.shiftKey)}
+                >
+                  {getElementLabel(element)}
+                </span>
+                <input
+                  className="app-input"
+                  type="number"
+                  defaultValue={duration ?? getDefaultDuration(element, allElements)}
+                  placeholder="ms"
+                  style={{ width: 52, minWidth: 52, flexShrink: 0, fontSize: 11 }}
+                  title="Duration in milliseconds"
+                  onBlur={(e) => {
+                    const val = Math.floor(Number(e.currentTarget.value));
+                    if (Number.isFinite(val) && val > 0) {
+                      setDuration(element.id, val);
+                    }
+                  }}
+                />
+              </div>
+            );
+          })}
+        </div>
       </div>
-    </div>
+    </>
   );
 };

--- a/src/AnimateConfigV2.tsx
+++ b/src/AnimateConfigV2.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type {
   ExcalidrawImperativeAPI,
 } from '@excalidraw/excalidraw/types';
@@ -6,9 +6,9 @@ import type { ExcalidrawElement } from '@excalidraw/excalidraw/element/types';
 
 import type { Drawing } from './AnimateConfig';
 
-const extractOrder = (id: string): number => {
+const extractOrder = (id: string): number | undefined => {
   const match = id.match(/animateOrder:(-?\d+)/);
-  return match ? Number(match[1]) : 0;
+  return match ? Number(match[1]) : undefined;
 };
 
 const extractDuration = (id: string): number | undefined => {
@@ -46,6 +46,18 @@ const getGroupColor = (groupId: string): string => {
   return GROUP_COLORS[Math.abs(hash) % GROUP_COLORS.length];
 };
 
+const getDefaultDuration = (
+  element: ExcalidrawElement,
+  allElements: ExcalidrawElement[],
+): number => {
+  const primaryGroupId = element.groupIds?.[0];
+  if (!primaryGroupId) return 500;
+  const groupSize = allElements.filter(
+    (el) => !el.isDeleted && el.groupIds?.[0] === primaryGroupId,
+  ).length;
+  return Math.round(5000 / (groupSize + 1));
+};
+
 const getElementLabel = (element: ExcalidrawElement): string => {
   if (element.type === 'text') {
     const text = (element as { text?: string }).text ?? '';
@@ -56,19 +68,23 @@ const getElementLabel = (element: ExcalidrawElement): string => {
   return `${element.type} [${shortId}]`;
 };
 
-// Returns the contiguous block bounds for the element at `index`.
-// Elements sharing the same primary groupId that are adjacent form one block.
-const getBlockContaining = (
-  elems: ExcalidrawElement[],
-  index: number,
-): { start: number; end: number } => {
-  const groupId = elems[index].groupIds?.[0];
-  if (!groupId) return { start: index, end: index };
-  let start = index;
-  while (start > 0 && elems[start - 1].groupIds?.[0] === groupId) start--;
-  let end = index;
-  while (end < elems.length - 1 && elems[end + 1].groupIds?.[0] === groupId) end++;
-  return { start, end };
+// Groups contiguous elements sharing the same primary groupId into blocks.
+const computeBlocks = (elems: ExcalidrawElement[]): { start: number; end: number }[] => {
+  const blocks: { start: number; end: number }[] = [];
+  let i = 0;
+  while (i < elems.length) {
+    const groupId = elems[i].groupIds?.[0] ?? null;
+    if (groupId) {
+      let j = i;
+      while (j < elems.length && elems[j].groupIds?.[0] === groupId) j++;
+      blocks.push({ start: i, end: j - 1 });
+      i = j;
+    } else {
+      blocks.push({ start: i, end: i });
+      i++;
+    }
+  }
+  return blocks;
 };
 
 type Props = {
@@ -80,16 +96,25 @@ export const AnimateConfigV2 = ({ drawing, api }: Props) => {
   const allElements = drawing.elements.filter((el) => !el.isDeleted);
 
   const sorted = [...allElements].sort((a, b) => {
-    const diff = extractOrder(a.id) - extractOrder(b.id);
+    const aOrder = extractOrder(a.id) ?? Infinity;
+    const bOrder = extractOrder(b.id) ?? Infinity;
+    const diff = aOrder - bOrder;
     if (diff !== 0) return diff;
     return drawing.elements.indexOf(a) - drawing.elements.indexOf(b);
   });
+
+  const blocks = computeBlocks(sorted);
 
   const selectedIds = drawing.appState.selectedElementIds ?? {};
 
   const rowRefMap = useRef<Map<string, HTMLDivElement>>(new Map());
   const sortedRef = useRef(sorted);
   sortedRef.current = sorted;
+
+  // dragBlockIdx: index in `blocks` of the block being dragged
+  // dropBlockIdx: insert dragged block BEFORE this block index (0..blocks.length)
+  const [dragBlockIdx, setDragBlockIdx] = useState<number | null>(null);
+  const [dropBlockIdx, setDropBlockIdx] = useState<number | null>(null);
 
   useEffect(() => {
     const firstSelected = sortedRef.current.find((el) => selectedIds[el.id]);
@@ -131,27 +156,60 @@ export const AnimateConfigV2 = ({ drawing, api }: Props) => {
     });
   };
 
-  // Moves the entire block containing `fromIndex` up or down one block.
-  const moveBlock = (fromIndex: number, direction: 'up' | 'down') => {
-    const block = getBlockContaining(sorted, fromIndex);
+  const handleDragStart = (e: React.DragEvent<HTMLDivElement>, blockIdx: number) => {
+    e.dataTransfer.effectAllowed = 'move';
+    setDragBlockIdx(blockIdx);
+  };
 
-    if (direction === 'up') {
-      if (block.start === 0) return;
-      const above = getBlockContaining(sorted, block.start - 1);
-      const newOrder = [...sorted];
-      const moved = newOrder.splice(block.start, block.end - block.start + 1);
-      newOrder.splice(above.start, 0, ...moved);
-      applyNewOrder(newOrder);
-    } else {
-      if (block.end >= sorted.length - 1) return;
-      const below = getBlockContaining(sorted, block.end + 1);
-      const blockSize = block.end - block.start + 1;
-      const newOrder = [...sorted];
-      const moved = newOrder.splice(block.start, blockSize);
-      // After removing the block, below.end shifts left by blockSize
-      newOrder.splice(below.end - blockSize + 1, 0, ...moved);
-      applyNewOrder(newOrder);
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>, rowIdx: number) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    const blockIdx = blocks.findIndex((b) => rowIdx >= b.start && rowIdx <= b.end);
+    const rect = e.currentTarget.getBoundingClientRect();
+    const target = e.clientY < rect.top + rect.height / 2 ? blockIdx : blockIdx + 1;
+    setDropBlockIdx(target);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    if (dragBlockIdx === null || dropBlockIdx === null) {
+      setDragBlockIdx(null);
+      setDropBlockIdx(null);
+      return;
     }
+    // No-op: dropping adjacent to itself
+    if (dropBlockIdx === dragBlockIdx || dropBlockIdx === dragBlockIdx + 1) {
+      setDragBlockIdx(null);
+      setDropBlockIdx(null);
+      return;
+    }
+
+    const draggedElems = sorted.slice(blocks[dragBlockIdx].start, blocks[dragBlockIdx].end + 1);
+    const newOrder: ExcalidrawElement[] = [];
+    let inserted = false;
+
+    blocks.forEach((block, bi) => {
+      if (bi === dropBlockIdx && !inserted) {
+        newOrder.push(...draggedElems);
+        inserted = true;
+      }
+      if (bi !== dragBlockIdx) {
+        newOrder.push(...sorted.slice(block.start, block.end + 1));
+      }
+    });
+
+    if (!inserted) {
+      newOrder.push(...draggedElems);
+    }
+
+    applyNewOrder(newOrder);
+    setDragBlockIdx(null);
+    setDropBlockIdx(null);
+  };
+
+  const handleDragEnd = () => {
+    setDragBlockIdx(null);
+    setDropBlockIdx(null);
   };
 
   const selectElement = (element: ExcalidrawElement) => {
@@ -216,13 +274,28 @@ export const AnimateConfigV2 = ({ drawing, api }: Props) => {
       >
         Animation Order
       </div>
-      <div style={{ flex: 1, overflowY: 'auto', minHeight: 0 }}>
+      <div
+        style={{ flex: 1, overflowY: 'auto', minHeight: 0 }}
+        onDragLeave={(e) => {
+          if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+            setDropBlockIdx(null);
+          }
+        }}
+      >
         {sorted.map((element, i) => {
           const duration = extractDuration(element.id);
           const isSelected = !!selectedIds[element.id];
           const primaryGroupId = element.groupIds?.[0];
           const groupColor = primaryGroupId ? getGroupColor(primaryGroupId) : undefined;
-          const block = getBlockContaining(sorted, i);
+          const blockIdx = blocks.findIndex((b) => i >= b.start && i <= b.end);
+          const isDragged = dragBlockIdx !== null && blockIdx === dragBlockIdx;
+          const showIndicatorBefore =
+            dropBlockIdx !== null &&
+            dropBlockIdx < blocks.length &&
+            blocks[dropBlockIdx].start === i;
+          const showIndicatorAfter =
+            dropBlockIdx === blocks.length && i === sorted.length - 1;
+
           return (
             <div
               key={element.id}
@@ -230,6 +303,9 @@ export const AnimateConfigV2 = ({ drawing, api }: Props) => {
                 if (node) rowRefMap.current.set(element.id, node);
                 else rowRefMap.current.delete(element.id);
               }}
+              onDragOver={(e) => handleDragOver(e, i)}
+              onDrop={handleDrop}
+              onDragEnd={handleDragEnd}
               style={{
                 display: 'flex',
                 alignItems: 'center',
@@ -238,9 +314,17 @@ export const AnimateConfigV2 = ({ drawing, api }: Props) => {
                 paddingLeft: groupColor ? 2 : 4,
                 borderRadius: 4,
                 borderLeft: groupColor ? `3px solid ${groupColor}` : '3px solid transparent',
+                borderTop: showIndicatorBefore ? '2px solid #4a90e2' : '2px solid transparent',
+                borderBottom: showIndicatorAfter ? '2px solid #4a90e2' : '2px solid transparent',
                 backgroundColor: isSelected ? 'rgba(100, 130, 255, 0.18)' : 'transparent',
+                opacity: isDragged ? 0.4 : 1,
               }}
             >
+              <div
+                className="drag-handle"
+                draggable
+                onDragStart={(e) => handleDragStart(e, blockIdx)}
+              />
               <span
                 style={{
                   width: 18,
@@ -267,28 +351,10 @@ export const AnimateConfigV2 = ({ drawing, api }: Props) => {
               >
                 {getElementLabel(element)}
               </span>
-              <button
-                className="app-button"
-                style={{ padding: '1px 5px', fontSize: 11, flexShrink: 0 }}
-                disabled={block.start === 0}
-                title="Move up"
-                onClick={() => moveBlock(i, 'up')}
-              >
-                ^
-              </button>
-              <button
-                className="app-button"
-                style={{ padding: '1px 5px', fontSize: 11, flexShrink: 0 }}
-                disabled={block.end === sorted.length - 1}
-                title="Move down"
-                onClick={() => moveBlock(i, 'down')}
-              >
-                v
-              </button>
               <input
                 className="app-input"
                 type="number"
-                defaultValue={duration ?? ''}
+                defaultValue={duration ?? getDefaultDuration(element, allElements)}
                 placeholder="ms"
                 style={{ width: 52, minWidth: 52, flexShrink: 0, fontSize: 11 }}
                 title="Duration in milliseconds"

--- a/src/ExcalidrawApp.tsx
+++ b/src/ExcalidrawApp.tsx
@@ -14,6 +14,8 @@ import { AnimateConfig } from './AnimateConfig';
 import { AnimateConfigV2 } from './AnimateConfigV2';
 import type { Drawing } from './AnimateConfig';
 
+const PANEL_MODE_KEY = 'animatePanelMode';
+
 type Props = {
   initialData:
     | { elements: ExcalidrawElement[]; appState: AppState; files: BinaryFiles }
@@ -30,19 +32,28 @@ const ExcalidrawApp = ({ initialData, onChangeData, theme }: Props) => {
   const [drawing, setDrawing] = useState<Drawing | undefined>(initialData);
   const [excalidrawAPI, setExcalidrawAPI] =
     useState<ExcalidrawImperativeAPI | null>(null);
-  const [panelMode, setPanelMode] = useState<'v1' | 'v2'>('v1');
-  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  const [panelMode, setPanelMode] = useState<'v1' | 'v2'>(
+    () => (localStorage.getItem(PANEL_MODE_KEY) as 'v1' | 'v2' | null) ?? 'v2',
+  );
+
+  // Sync with Excalidraw's persisted sidebar state so our toggle logic stays correct.
+  const [sidebarOpen, setSidebarOpen] = useState(
+    () => !!(initialData?.appState as Record<string, unknown> | undefined)?.openSidebar,
+  );
 
   const handleToggle = (mode: 'v1' | 'v2') => {
     if (!excalidrawAPI) return;
     if (sidebarOpen && panelMode !== mode) {
       setPanelMode(mode);
+      localStorage.setItem(PANEL_MODE_KEY, mode);
       return;
     }
     const isNowOpen = excalidrawAPI.toggleSidebar({ name: 'custom' });
     setSidebarOpen(isNowOpen);
     if (isNowOpen) {
       setPanelMode(mode);
+      localStorage.setItem(PANEL_MODE_KEY, mode);
     }
   };
 

--- a/src/ExcalidrawApp.tsx
+++ b/src/ExcalidrawApp.tsx
@@ -11,6 +11,7 @@ import type { ExcalidrawElement } from '@excalidraw/excalidraw/element/types';
 import '@excalidraw/excalidraw/index.css';
 
 import { AnimateConfig } from './AnimateConfig';
+import { AnimateConfigV2 } from './AnimateConfigV2';
 import type { Drawing } from './AnimateConfig';
 
 type Props = {
@@ -29,6 +30,22 @@ const ExcalidrawApp = ({ initialData, onChangeData, theme }: Props) => {
   const [drawing, setDrawing] = useState<Drawing | undefined>(initialData);
   const [excalidrawAPI, setExcalidrawAPI] =
     useState<ExcalidrawImperativeAPI | null>(null);
+  const [panelMode, setPanelMode] = useState<'v1' | 'v2'>('v1');
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  const handleToggle = (mode: 'v1' | 'v2') => {
+    if (!excalidrawAPI) return;
+    if (sidebarOpen && panelMode !== mode) {
+      setPanelMode(mode);
+      return;
+    }
+    const isNowOpen = excalidrawAPI.toggleSidebar({ name: 'custom' });
+    setSidebarOpen(isNowOpen);
+    if (isNowOpen) {
+      setPanelMode(mode);
+    }
+  };
+
   return (
     <div style={{ height: '100vh', width: '100vw' }}>
       <Excalidraw
@@ -52,24 +69,37 @@ const ExcalidrawApp = ({ initialData, onChangeData, theme }: Props) => {
       >
         <Sidebar name="custom" docked={true}>
           <Sidebar.Header />
-          <div style={{ padding: '1rem' }}>
+          <div style={{ padding: '1rem', display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, boxSizing: 'border-box', overflow: 'hidden' }}>
             {drawing && excalidrawAPI ? (
-              <AnimateConfig drawing={drawing} api={excalidrawAPI} />
+              panelMode === 'v2' ? (
+                <AnimateConfigV2 drawing={drawing} api={excalidrawAPI} />
+              ) : (
+                <AnimateConfig drawing={drawing} api={excalidrawAPI} />
+              )
             ) : (
               <p>Loading...</p>
             )}
           </div>
         </Sidebar>
         <Footer>
-          <Sidebar.Trigger
-            name="custom"
-            style={{
-              marginLeft: '0.5rem',
-            }}
+          <button
+            className="sidebar-trigger"
+            aria-pressed={sidebarOpen && panelMode === 'v1'}
             title="Show or hide the Animate panel"
+            style={{ marginLeft: '0.5rem' }}
+            onClick={() => handleToggle('v1')}
           >
-            Toggle Animate Panel
-          </Sidebar.Trigger>
+            <div className="sidebar-trigger__label">Toggle Animate Panel</div>
+          </button>
+          <button
+            className="sidebar-trigger"
+            aria-pressed={sidebarOpen && panelMode === 'v2'}
+            title="Show or hide the Animate panel v2"
+            style={{ marginLeft: '0.5rem' }}
+            onClick={() => handleToggle('v2')}
+          >
+            <div className="sidebar-trigger__label">Toggle Animate Panel v2</div>
+          </button>
         </Footer>
       </Excalidraw>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -82,6 +82,19 @@
   --right-sidebar-width: 453px !important;
 }
 
+.drag-handle {
+  width: 8px;
+  height: 16px;
+  flex-shrink: 0;
+  cursor: grab;
+  opacity: 0.4;
+  background-image: radial-gradient(circle, currentColor 1.2px, transparent 1.2px);
+  background-size: 4px 5px;
+}
+.drag-handle:hover {
+  opacity: 0.75;
+}
+
 :root.dark .excalidraw .animate-config {
   /* Direct values because var(--input-bg-color) doesn't resolve here */
   --animate-config-input-bg-color: #31303b;

--- a/src/index.css
+++ b/src/index.css
@@ -78,6 +78,10 @@
   --button-active-border: var(--color-brand-active);
 }
 
+.excalidraw {
+  --right-sidebar-width: 453px !important;
+}
+
 :root.dark .excalidraw .animate-config {
   /* Direct values because var(--input-bg-color) doesn't resolve here */
   --animate-config-input-bg-color: #31303b;


### PR DESCRIPTION
Hey, Daichi!

First of all, thanks for this tool. It's super cool!

I've started to play with it today and I found the UX for reordering the elements to be not optimal since I had to select each one to inspect their order and duration on the animate panel.
I had the idea of creating a different panel for the same purpose. With this "Animate Panel v2" (as I called it):

**Reorder**: Drag a row by its grip handle (dotted area on the left). Grouped elements always move together as a block.
**Select**: Click an element name to select it on the canvas. Clicking any member of a group selects the whole group. Hold Shift and click to add items to the current selection, or to remove an already-selected item from it.
**Duration**: The number input on the right of each row sets that element's animation duration in milliseconds. Values shown in gray are defaults computed from the animation engine.
**Batch duration**: Enter a value in the "Set duration" field and click Apply. If elements are selected on the canvas, only those are updated; otherwise all elements are updated.
**Groups**: The colored bar on the left edge of a row indicates the element belongs to a group. Rows sharing the same color are in the same group.
**New elements**: Elements added to the canvas appear at the bottom of the list with no explicit order set. Drag them into position to fix their order.

Since I'm an Unreal C++ dev and I have no time to learn React, I vibe coded this with Claude Code.
So, I have no idea if the code is slop or not. But its working for my purposes.
I hope you can review and integrate this when you have the time.

Here is a video of me using it:
https://www.youtube.com/watch?v=k7tgdSxpfTE

Cheers!